### PR TITLE
Add in quality check

### DIFF
--- a/BirdData_GLMSingle_Processing.ipynb
+++ b/BirdData_GLMSingle_Processing.ipynb
@@ -1,0 +1,4522 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Goal\n",
+    "\n",
+    "The goal of this notebook is to document how to extract GLMSingle beta values on a specific subject from the bird data setup, do some quality checks etc.\n",
+    "A broad breakdown of these steps are given in the following:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* TBD - when notebook complete"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import libraries and then load up the events data structure to prepare the design matrix for the runs of this subject. Load the CSV file into memory as a pandas `DataFrame` object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>onset</th>\n",
+       "      <th>duration</th>\n",
+       "      <th>tr</th>\n",
+       "      <th>stimulus</th>\n",
+       "      <th>class_id</th>\n",
+       "      <th>class_name</th>\n",
+       "      <th>image_number</th>\n",
+       "      <th>same</th>\n",
+       "      <th>response</th>\n",
+       "      <th>response_time_ms</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>+</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>10.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>5.00</td>\n",
+       "      <td>docs\\cropped\\174.Palm_Warbler_3.png</td>\n",
+       "      <td>174.0</td>\n",
+       "      <td>Palm_Warbler</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>15.5</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>7.75</td>\n",
+       "      <td>+</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>16.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>8.00</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_2.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>21.5</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>10.75</td>\n",
+       "      <td>+</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   onset  duration     tr                               stimulus  class_id  \\\n",
+       "0    0.0      10.0   0.00                                      +       NaN   \n",
+       "1   10.0       5.5   5.00    docs\\cropped\\174.Palm_Warbler_3.png     174.0   \n",
+       "2   15.5       0.5   7.75                                      +       NaN   \n",
+       "3   16.0       5.5   8.00  docs\\cropped\\182.Yellow_Warbler_2.png     182.0   \n",
+       "4   21.5       0.5  10.75                                      +       NaN   \n",
+       "\n",
+       "       class_name  image_number   same  response  response_time_ms  \n",
+       "0             NaN           NaN    NaN       NaN               NaN  \n",
+       "1    Palm_Warbler           3.0  False       NaN               NaN  \n",
+       "2             NaN           NaN    NaN       NaN               NaN  \n",
+       "3  Yellow_Warbler           2.0  False       NaN               NaN  \n",
+       "4             NaN           NaN    NaN       NaN               NaN  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np \n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "import nibabel as nib\n",
+    "import nilearn as nil \n",
+    "import nilearn.surface as surf\n",
+    "import sklearn\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "import glmsingle\n",
+    "from glmsingle.glmsingle import GLM_single\n",
+    "\n",
+    "folder = Path('/Users/alxmrphi/Documents/Data/Bird/jamestest/Tc2See_35/study/csv_files')\n",
+    "file = Path('TC2See_35_1_result_store.csv')\n",
+    "path = folder / file\n",
+    "\n",
+    "df = pd.read_csv(path, sep='\\t')\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are only interested in the events where an image was presented, so we filter this dataframe by looking for rows that have a string object that ends with `.png`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>onset</th>\n",
+       "      <th>duration</th>\n",
+       "      <th>tr</th>\n",
+       "      <th>stimulus</th>\n",
+       "      <th>class_id</th>\n",
+       "      <th>class_name</th>\n",
+       "      <th>image_number</th>\n",
+       "      <th>same</th>\n",
+       "      <th>response</th>\n",
+       "      <th>response_time_ms</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>10.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>docs\\cropped\\174.Palm_Warbler_3.png</td>\n",
+       "      <td>174.0</td>\n",
+       "      <td>Palm_Warbler</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>16.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_2.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>22.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>11.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_4.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>3402.803225</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>28.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>14.0</td>\n",
+       "      <td>docs\\cropped\\172.Nashville_Warbler_1.png</td>\n",
+       "      <td>172.0</td>\n",
+       "      <td>Nashville_Warbler</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>34.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>17.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_4.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   onset  duration    tr                                  stimulus  class_id  \\\n",
+       "1   10.0       5.5   5.0       docs\\cropped\\174.Palm_Warbler_3.png     174.0   \n",
+       "3   16.0       5.5   8.0     docs\\cropped\\182.Yellow_Warbler_2.png     182.0   \n",
+       "5   22.0       5.5  11.0     docs\\cropped\\182.Yellow_Warbler_4.png     182.0   \n",
+       "7   28.0       5.5  14.0  docs\\cropped\\172.Nashville_Warbler_1.png     172.0   \n",
+       "9   34.0       5.5  17.0     docs\\cropped\\182.Yellow_Warbler_4.png     182.0   \n",
+       "\n",
+       "          class_name  image_number   same  response  response_time_ms  \n",
+       "1       Palm_Warbler           3.0  False       NaN               NaN  \n",
+       "3     Yellow_Warbler           2.0  False       NaN               NaN  \n",
+       "5     Yellow_Warbler           4.0   True       3.0       3402.803225  \n",
+       "7  Nashville_Warbler           1.0  False       NaN               NaN  \n",
+       "9     Yellow_Warbler           4.0  False       NaN               NaN  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "events_df = df[df['stimulus'].str.endswith('png')]\n",
+    "events_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now need to replace `stimulus` with its filename (starting after the integer and full stop). Then additionally use the saved mapping between filenames and indices to create another column (called `filename`) with that value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pickle \n",
+    "\n",
+    "idx_to_fname = pickle.load(open('idx_to_fname.pkl', 'rb'))\n",
+    "fname_to_idx = pickle.load(open('fname_to_idx.pkl', 'rb'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/1836307698.py:5: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['filename'] = events_df['stimulus'].apply(process_stim_column)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>onset</th>\n",
+       "      <th>duration</th>\n",
+       "      <th>tr</th>\n",
+       "      <th>stimulus</th>\n",
+       "      <th>class_id</th>\n",
+       "      <th>class_name</th>\n",
+       "      <th>image_number</th>\n",
+       "      <th>same</th>\n",
+       "      <th>response</th>\n",
+       "      <th>response_time_ms</th>\n",
+       "      <th>filename</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>10.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>docs\\cropped\\174.Palm_Warbler_3.png</td>\n",
+       "      <td>174.0</td>\n",
+       "      <td>Palm_Warbler</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Palm_Warbler_3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>16.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_2.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>22.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>11.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_4.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>3402.803225</td>\n",
+       "      <td>Yellow_Warbler_4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>28.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>14.0</td>\n",
+       "      <td>docs\\cropped\\172.Nashville_Warbler_1.png</td>\n",
+       "      <td>172.0</td>\n",
+       "      <td>Nashville_Warbler</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Nashville_Warbler_1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>34.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>17.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_4.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   onset  duration    tr                                  stimulus  class_id  \\\n",
+       "1   10.0       5.5   5.0       docs\\cropped\\174.Palm_Warbler_3.png     174.0   \n",
+       "3   16.0       5.5   8.0     docs\\cropped\\182.Yellow_Warbler_2.png     182.0   \n",
+       "5   22.0       5.5  11.0     docs\\cropped\\182.Yellow_Warbler_4.png     182.0   \n",
+       "7   28.0       5.5  14.0  docs\\cropped\\172.Nashville_Warbler_1.png     172.0   \n",
+       "9   34.0       5.5  17.0     docs\\cropped\\182.Yellow_Warbler_4.png     182.0   \n",
+       "\n",
+       "          class_name  image_number   same  response  response_time_ms  \\\n",
+       "1       Palm_Warbler           3.0  False       NaN               NaN   \n",
+       "3     Yellow_Warbler           2.0  False       NaN               NaN   \n",
+       "5     Yellow_Warbler           4.0   True       3.0       3402.803225   \n",
+       "7  Nashville_Warbler           1.0  False       NaN               NaN   \n",
+       "9     Yellow_Warbler           4.0  False       NaN               NaN   \n",
+       "\n",
+       "              filename  \n",
+       "1       Palm_Warbler_3  \n",
+       "3     Yellow_Warbler_2  \n",
+       "5     Yellow_Warbler_4  \n",
+       "7  Nashville_Warbler_1  \n",
+       "9     Yellow_Warbler_4  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def process_stim_column(stimulus):\n",
+    "    assert type(stimulus) == str\n",
+    "    return stimulus.split('.')[1:-1][0]\n",
+    "    \n",
+    "events_df['filename'] = events_df['stimulus'].apply(process_stim_column)\n",
+    "events_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the loaded mapping, we now create another column that takes the `filename` and adds a column with the correct filename id."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/3489059137.py:4: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>onset</th>\n",
+       "      <th>duration</th>\n",
+       "      <th>tr</th>\n",
+       "      <th>stimulus</th>\n",
+       "      <th>class_id</th>\n",
+       "      <th>class_name</th>\n",
+       "      <th>image_number</th>\n",
+       "      <th>same</th>\n",
+       "      <th>response</th>\n",
+       "      <th>response_time_ms</th>\n",
+       "      <th>filename</th>\n",
+       "      <th>file_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>10.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>docs\\cropped\\174.Palm_Warbler_3.png</td>\n",
+       "      <td>174.0</td>\n",
+       "      <td>Palm_Warbler</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Palm_Warbler_3</td>\n",
+       "      <td>203</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>16.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_2.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_2</td>\n",
+       "      <td>292</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>22.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>11.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_4.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>3402.803225</td>\n",
+       "      <td>Yellow_Warbler_4</td>\n",
+       "      <td>294</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>28.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>14.0</td>\n",
+       "      <td>docs\\cropped\\172.Nashville_Warbler_1.png</td>\n",
+       "      <td>172.0</td>\n",
+       "      <td>Nashville_Warbler</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Nashville_Warbler_1</td>\n",
+       "      <td>171</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>34.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>17.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_4.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_4</td>\n",
+       "      <td>294</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   onset  duration    tr                                  stimulus  class_id  \\\n",
+       "1   10.0       5.5   5.0       docs\\cropped\\174.Palm_Warbler_3.png     174.0   \n",
+       "3   16.0       5.5   8.0     docs\\cropped\\182.Yellow_Warbler_2.png     182.0   \n",
+       "5   22.0       5.5  11.0     docs\\cropped\\182.Yellow_Warbler_4.png     182.0   \n",
+       "7   28.0       5.5  14.0  docs\\cropped\\172.Nashville_Warbler_1.png     172.0   \n",
+       "9   34.0       5.5  17.0     docs\\cropped\\182.Yellow_Warbler_4.png     182.0   \n",
+       "\n",
+       "          class_name  image_number   same  response  response_time_ms  \\\n",
+       "1       Palm_Warbler           3.0  False       NaN               NaN   \n",
+       "3     Yellow_Warbler           2.0  False       NaN               NaN   \n",
+       "5     Yellow_Warbler           4.0   True       3.0       3402.803225   \n",
+       "7  Nashville_Warbler           1.0  False       NaN               NaN   \n",
+       "9     Yellow_Warbler           4.0  False       NaN               NaN   \n",
+       "\n",
+       "              filename  file_id  \n",
+       "1       Palm_Warbler_3      203  \n",
+       "3     Yellow_Warbler_2      292  \n",
+       "5     Yellow_Warbler_4      294  \n",
+       "7  Nashville_Warbler_1      171  \n",
+       "9     Yellow_Warbler_4      294  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def stimulus_to_class(stimulus2):\n",
+    "    return fname_to_idx[stimulus2]\n",
+    "\n",
+    "events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)\n",
+    "events_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we load the corresponding fMRI data (here: surface format) and we can extract the time series and relevant statistics needed to specify the design matrix. \n",
+    "\n",
+    "NB: this is only the left hemisphere. Not sure how you want to do this but I think saving Left vs Right hemisphere separately might be better and then combine them at the downstream stage of ML pipeline. This way it's easier to just load and plot since the fsaverage surfaces are also with split hemispheres."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n_vertices = 163842, n_timepoints = 236, n_conds = 300\n"
+     ]
+    }
+   ],
+   "source": [
+    "func_folder = Path('/Users/alxmrphi/Documents/Data/Bird/jamestest/TC2See_35/study/sub-35/sub-35/func')\n",
+    "func_file = Path('sub-35_task-bird_run-1_hemi-L_space-fsaverage_bold.func.gii')\n",
+    "\n",
+    "import nilearn as nil \n",
+    "import nilearn.surface as surf\n",
+    "\n",
+    "# load fMRI gii file\n",
+    "func_path = func_folder / func_file\n",
+    "fmri = surf.load_surf_data(func_path)\n",
+    "n_conds = len(fname_to_idx) # number of keys in the mapping dictionary\n",
+    "n_vertices, n_timepoints = fmri.shape\n",
+    "\n",
+    "print(f'{n_vertices = }, {n_timepoints = }, {n_conds = }')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then you use the same amount of time points as the corresponding processed fMRI data (`n_timepoints`) and create a zeros matrix of shape `(n_timepoints, n_conditions)`. You go through each row and take the corresponding TR value (`tr`) and stimulus ID (`file_id`) and add 1s in the zeros matrix until the design matrix is completed by processing all the rows.\n",
+    "\n",
+    "Shapes:\n",
+    "\n",
+    "* design = (n_timepoints=236, n_conds=300)\n",
+    "* data = (n_timepoints=236, n_vertices=163842)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "design = np.zeros((n_timepoints, n_conds))\n",
+    "\n",
+    "for t in range(len(events_df)):\n",
+    "    tr, idx = events_df.iloc[t][['tr', 'file_id']]\n",
+    "    tr = int(tr)\n",
+    "    design[tr, idx] = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, for every image presentation the TR value found in the same row has been updated to be a `1` in the design matrix. Let's verify this works as expected. We will plot the first two lines of the events dataframe and look at the filename, file_id etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>onset</th>\n",
+       "      <th>duration</th>\n",
+       "      <th>tr</th>\n",
+       "      <th>stimulus</th>\n",
+       "      <th>class_id</th>\n",
+       "      <th>class_name</th>\n",
+       "      <th>image_number</th>\n",
+       "      <th>same</th>\n",
+       "      <th>response</th>\n",
+       "      <th>response_time_ms</th>\n",
+       "      <th>filename</th>\n",
+       "      <th>file_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>10.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>docs\\cropped\\174.Palm_Warbler_3.png</td>\n",
+       "      <td>174.0</td>\n",
+       "      <td>Palm_Warbler</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Palm_Warbler_3</td>\n",
+       "      <td>203</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>16.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_2.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_2</td>\n",
+       "      <td>292</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   onset  duration   tr                               stimulus  class_id  \\\n",
+       "1   10.0       5.5  5.0    docs\\cropped\\174.Palm_Warbler_3.png     174.0   \n",
+       "3   16.0       5.5  8.0  docs\\cropped\\182.Yellow_Warbler_2.png     182.0   \n",
+       "\n",
+       "       class_name  image_number   same  response  response_time_ms  \\\n",
+       "1    Palm_Warbler           3.0  False       NaN               NaN   \n",
+       "3  Yellow_Warbler           2.0  False       NaN               NaN   \n",
+       "\n",
+       "           filename  file_id  \n",
+       "1    Palm_Warbler_3      203  \n",
+       "3  Yellow_Warbler_2      292  "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "events_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This means we expect that column 203 has a `1` at the 5th `tr` value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.int64(203)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "design[5,:].argmax()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "203"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fname_to_idx['Palm_Warbler_3']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The above lines show that column `203` is associated with the file `Palm_Warbler_3` so in the design matrix as expected."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The code below is boilerplate code from the GLMSingle tutorial, can be ignored for now."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'wantlibrary': 1, 'wantglmdenoise': 1, 'wantfracridge': 1, 'wantfileoutputs': [1, 1, 1, 1], 'wantmemoryoutputs': [1, 1, 1, 1], 'numforhrf': 50, 'hrfthresh': 0.5, 'hrffitmask': 1, 'R2thresh': 0, 'hrfmodel': 'optimise', 'n_jobs': 1, 'n_pcs': 10, 'n_boots': 100, 'extra_regressors': False, 'chunklen': 50000, 'wanthdf5': 0, 'wantparametric': 0, 'wantpercentbold': 1, 'wantlss': 0, 'brainthresh': [99.0, 0.1], 'brainR2': [], 'brainexclude': False, 'pcR2cutoff': [], 'pcR2cutoffmask': 1, 'pcstop': 1.05, 'fracs': array([1.  , 0.95, 0.9 , 0.85, 0.8 , 0.75, 0.7 , 0.65, 0.6 , 0.55, 0.5 ,\n",
+      "       0.45, 0.4 , 0.35, 0.3 , 0.25, 0.2 , 0.15, 0.1 , 0.05]), 'wantautoscale': 1, 'seed': 1732619319.067295, 'suppressoutput': 0, 'lambda': 0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "opt = dict()\n",
+    "\n",
+    "# set important fields for completeness (but these would be enabled by default)\n",
+    "opt['wantlibrary'] = 1\n",
+    "opt['wantglmdenoise'] = 1\n",
+    "opt['wantfracridge'] = 1\n",
+    "\n",
+    "# for the purpose of this example we will keep the relevant outputs in memory\n",
+    "# and also save them to the disk\n",
+    "opt['wantfileoutputs'] = [1,1,1,1]\n",
+    "opt['wantmemoryoutputs'] = [1,1,1,1]\n",
+    "\n",
+    "# running python GLMsingle involves creating a GLM_single object\n",
+    "# and then running the procedure using the .fit() routine\n",
+    "glmsingle_obj = GLM_single(opt)\n",
+    "\n",
+    "# visualize all the hyperparameters\n",
+    "print(glmsingle_obj.params)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's write a function to load the fMRI data, events file and create the data and design matrices for a specific subject."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_data_and_design_matrices(sub_no, run_no):\n",
+    "    \"\"\"Docstring: TBD \"\"\"\n",
+    "    func_file = Path(f'sub-{sub_no}_task-bird_run-{run_no}_hemi-L_space-fsaverage_bold.func.gii')\n",
+    "    data = surf.load_surf_data(func_folder / func_file)\n",
+    "    file = Path(f'TC2See_35_{run_no}_result_store.csv')\n",
+    "    path = folder / file\n",
+    "    df = pd.read_csv(path, sep='\\t')\n",
+    "    events_df = df[df['stimulus'].str.endswith('png')] \n",
+    "    events_df['filename'] = events_df['stimulus'].apply(process_stim_column)\n",
+    "    events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)\n",
+    "    design = np.zeros((n_timepoints, n_conds))\n",
+    "\n",
+    "    for t in range(len(events_df)):\n",
+    "        tr, idx = events_df.iloc[t][['tr', 'file_id']]\n",
+    "        tr = int(tr)\n",
+    "        design[tr, idx] = 1\n",
+    "\n",
+    "    return design, data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's run it on the 6 runs for this subject."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:9: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['filename'] = events_df['stimulus'].apply(process_stim_column)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:10: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:9: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['filename'] = events_df['stimulus'].apply(process_stim_column)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:10: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:9: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['filename'] = events_df['stimulus'].apply(process_stim_column)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:10: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:9: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['filename'] = events_df['stimulus'].apply(process_stim_column)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:10: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:9: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['filename'] = events_df['stimulus'].apply(process_stim_column)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:10: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:9: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['filename'] = events_df['stimulus'].apply(process_stim_column)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/2274337206.py:10: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)\n"
+     ]
+    }
+   ],
+   "source": [
+    "design1, data1 = get_data_and_design_matrices(35, 1)\n",
+    "design2, data2 = get_data_and_design_matrices(35, 2)\n",
+    "design3, data3 = get_data_and_design_matrices(35, 3)\n",
+    "design4, data4 = get_data_and_design_matrices(35, 4)\n",
+    "design5, data5 = get_data_and_design_matrices(35, 5)\n",
+    "design6, data6 = get_data_and_design_matrices(35, 6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next apply normalisation to the beta values to make them mean-centred and unit standard deviation (for stability and comparability across the fMRI runs). Note that this means you won't need to apply normalisation at a later step in the ML paradigm. I'm not 100% sure if this is required but felt safer to do so. Will check this out later. 99% sure this isn't an issue to apply it at this stage, more of an issue to not apply it and get weird results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data1_ = StandardScaler().fit_transform(data1)\n",
+    "data2_ = StandardScaler().fit_transform(data2)\n",
+    "data3_ = StandardScaler().fit_transform(data3)\n",
+    "data4_ = StandardScaler().fit_transform(data4)\n",
+    "data5_ = StandardScaler().fit_transform(data5)\n",
+    "data6_ = StandardScaler().fit_transform(data6)\n",
+    "\n",
+    "data_list = [data1_, data2_, data3_, data4_, data5_, data6_]\n",
+    "design_list = [design1, design2, design3, design4, design5, design6]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check shapes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(163842, 236),\n",
+       " (163842, 236),\n",
+       " (163842, 236),\n",
+       " (163842, 236),\n",
+       " (163842, 236),\n",
+       " (163842, 236)]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[x.shape for x in data_list]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(236, 300), (236, 300), (236, 300), (236, 300), (236, 300), (236, 300)]"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[x.shape for x in design_list]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can combine all the design matrices from each run and plot the overall design matrix for the classes of the images seen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "design_all = np.zeros(design_list[0].shape)\n",
+    "for d in design_list:\n",
+    "    design_all += d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAAK/CAYAAAB0qWwmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAABVCElEQVR4nO3deXyU1d3///eEQMKWhBCyQQgBQfYtrIKCQiFQQCUimzYgYqWAVUQt/SpI73pjudtbH7a2au9W3BdUcF8QBFQCIggICFobCFsA2deQkPP7w1+mjEkmk8mZNa/n45HHg8y1zLmu68w1eXNmzsdhjDECAAAAAFRbRKAbAAAAAADhgoAFAAAAAJYQsAAAAADAEgIWAAAAAFhCwAIAAAAASwhYAAAAAGAJAQsAAAAALCFgAQAAAIAlBCwAAAAAsISABQA+tmvXLjkcDrVo0SLQTQl4WwYOHCiHw6GVK1cG5PlrshYtWsjhcGjXrl0+f67jx49r+vTpSk9PV506deRwODRw4ECfPy8qt2fPHj355JO67bbblJmZqaioKDkcDt16662BbhoQNiID3QAAAFCxFi1aaPfu3crLywuKkO6J2267TYsXL1aLFi00evRoRUdHq23btoFuFiS9/vrruuuuuwLdDCCsEbAAAH7z7LPP6uzZs2revHmgm1LjLF++XEVFRWratKlPn6eoqEhLlixRdHS0Nm/erJiYGJ8+H6omIyNDM2fOVPfu3dW9e3e9+uqreuihhwLdLCCsELAAAH5DsAqcVq1a+eV5Dhw4oOLiYjVt2pRwFYSuvfZaXXvttc7f33jjjQC2BghPfAcLgNfOnTunP/3pT+rTp4/i4uIUHR2tyy+/XPfee6+OHDnisu5rr70mh8OhJk2aaO/evWX29eGHH6pWrVqKjY3Vd99953z88OHDeuyxxzR8+HBlZGSobt26iomJUY8ePfSHP/xB58+fL7dtDodDDodDkvT888+rV69eatCggZo0aaLx48crPz9fkmSM0V/+8hd17dpV9evXV0JCgiZNmqRDhw6V2eeiRYvkcDg0adIkHTlyRNOnT1fz5s0VFRWl9PR03XXXXTp27JhPz6On3nnnHQ0YMEANGzZUbGysrrzySr355puVbnfs2DHNmzdPXbt2VcOGDVWvXj116tRJv//973X27Nky65eUlOipp55Sv379FBcXp9q1aysxMVFdunTRzJkzy3zfx913sM6cOaMHHnhArVu3VlRUlFJTU3XLLbdo3759evDBB+VwOPTggw+6bHPp44cPH9b06dOVlpamOnXqKC0tTTNnztTx48ercOaklStXOr8zVFhYqPnz56tNmzaKjo5W8+bNdd999zn73YkTJzR79my1bNlS0dHRatGihR588EEVFxeX2W9V+3Jpf9u9e7ekH0ceSvv1pefw0vaePXtWc+fOVbt27VSvXj2XjxSW9x0sb1+XFXE4HEpPT5ck7d69u9z2Tpo0SQ6HQ4sWLdLWrVs1duxYpaSkqFatWi7X9+jRo/rtb3+rDh06qF69emrYsKEyMzO1cOFCnTt3zm/XzZ1L+19+fr6mTJmitLQ01a5dW5MmTZLket8oT0Xfi7z0cWOMnnrqKWVmZqp+/fqKjY3VkCFDlJubW6X2AvATAwBe2Ldvn+nUqZORZOLj483gwYPN9ddfb9LT040k06JFC7Nr1y6XbWbOnGkkmf79+5uioiLn43v37jVNmjQxkswrr7ziss1zzz1nJJmmTZuaAQMGmHHjxplBgwaZBg0aGEmmb9++5vz582XaJ8lIMr/5zW9MZGSkueaaa8wNN9xgmjdvbiSZtLQ0c/ToUXPjjTea6Ohok5WVZa6//nqTmJhoJJnOnTubwsJCl30+/fTTRpIZNWqUadWqlYmLizPXXXeduf76602jRo2MJHP55ZebQ4cOuWyXl5dnJJn09HQr57Ey//u//+s8/l69epnx48ebHj16GElm1qxZFbZl27ZtJi0tzUgyKSkpJisry4wcOdIkJSUZSaZr167m+PHjLttMnjzZSDLR0dFm8ODBZvz48Wbo0KGmdevWRpJZsmSJy/oDBgwwkswnn3zi8vjp06dNz549jSTToEEDM2LECDNmzBiTkpJiEhMTzaRJk4wkM2/ePJft5s2bZySZW265xTRr1swkJSWZ0aNHm+HDh5vY2FgjyfTs2dNcuHDB4/P3ySefOPvWgAEDTExMjBk1apQZMWKEc58jRowwR44cMZdffrlp0qSJyc7ONkOGDDHR0dFGkrn99tvL7LeqffnTTz81OTk5pn79+kaSyc7ONjk5Oc6fb775xqW9vXv3Nj179jT169c3w4YNM2PHjjWDBw927q+0T+Xl5bm0y5vXZUVycnJMdna2kWTq169fbntzcnKMJDN16lQTFRVlWrRoYW688UYzcuRI88c//tEYY8z333/vbG/p+R01apRp2LChkWS6d+9ujh496pfr5k5p/5swYYKJj483ycnJJjs724wePdrcfffdxpj/3DdycnLK3UdF94dLH8/JyTG1a9c211xzjbnxxhtNmzZtjCQTFRVl1q5dW6U2V3QMU6ZMqdZ+APwHAQtAlZWUlJh+/fo535RPnjzpXFZUVGTuvvtuI8lcffXVLtsVFhaaXr16GUnmvvvuc67fv39/I8lMnz69zHNt377d5Obmlnn86NGjZsiQIUaSWbhwYZnlpQGjcePGZtOmTc7Hz54963y+Tp06mVatWrkEmMOHD5vLLrvMSDLPP/+8yz5L/1CSZPr06WOOHDniXHbs2DFzxRVXGElm3LhxLttV9AeUt+fRnc2bN5tatWqZiIgIs3jxYpdlzz//vHE4HOW25ezZs6ZVq1ZGkrn//vtdwuWZM2fM+PHjjSQzefJk5+O7d+82kkyzZs3MgQMHyrRl+/btZvfu3S6PVRSw7rrrLiPJtG/f3uzfv9/5+Llz58wNN9zgPO8VBSxJZtKkSS4BJT8/3zRt2tRIMi+++KLb83ap0j/USwPqDz/84Fy2a9cuZ5ju1KmTGTlypDlz5oxz+fr1601kZKSJiIgoc+ze9uWKglF57e3cuXO518Ldfrx5Xbrj7j8UjPlPwCr9D5CLFy+WWad3797O/8w4ffq08/FDhw6Z7t27O0PNpXx13dy5tP/ddNNN5f5nT3UDVumynTt3OpcVFxebW265xUgyQ4YM8bi97o6BgAXYQ8ACUGXvv/++c0Tj0v/xLnXx4kXTsWNHI8l8/fXXLsvy8vJMo0aNjMPhMO+++6659957jSSTmZlZ7h8n7uzcudM5QvFTpX+YPP7442WWvfHGG87l7777bpnlf/rTn8qECWNcA9ZXX31VZrstW7YYh8NhIiIizJ49e1yOubw/oKpzHity6623Gklm7Nix5S6/9tpry23L3/72N+f/8Jfn1KlTJjEx0URGRjpHDr744gvnH8GeKi9gnT171jmK8+GHH5bZ5tChQ6ZevXpuA1azZs1c/mAu9fDDDztHuDxV+oe6w+Eo97zfcccdzpG2gwcPllk+cuRII8k888wzHj+nu75clYC1evXqCp/D3X5svi49DVht2rQxxcXFZZZ/+umnRpKpV6+eKSgoKLP8yy+/NJLKvM4Ccd1K+198fHyZ0d1SNgLWW2+9VWa7AwcOOEexqjJCW9ExELAAe5jkAkCVvfvuu5Kk7OxsRUaWvY1EREToqquu0tatW7VmzRp17NjRuaxFixZatGiRrrvuOo0fP16nTp1SbGysXn31VUVFRZX7fBcvXtTKlSu1Zs0aHThwQOfOnZP58T+IJEk7d+6ssK3Dhw8v81jr1q0lSZGRkRoyZEiFy/fv31/uPrt06aKuXbuWebxTp07q1q2bNm7cqNWrV2vChAkVtkuq3nmsSOn3XG666aZyl+fk5JT7XazStowdO7bc7Ro0aKAePXrovffe0/r16zVkyBC1bdtWDRs21HvvvaeHHnpIEyZMUEZGRqVt/KkNGzbo9OnTSkhIKPd6NGnSRD/72c/cfods0KBBqlevXpnH27VrJ0nat29fldvVvHnzcs95af/IzMxUYmJihcvL6z/V6cuVSUxM1JVXXunVtt68LqvruuuuU61atco8XtqHs7KylJSUVGZ5ZmamunTpos2bN2vVqlWaOHGiy3JfXLfKDB48WLGxsVXezhORkZHKysoq83hycrIaNWqkY8eO6ciRI0pOTvbJ8wOoOgIWgCr797//LUl64IEH9MADD7hd9/Dhw2UeGzVqlG699Vb9/e9/lyQ99dRTatmyZbnbf/fdd7r++uu1bdu2Cp/j5MmTFS4rb9a6Bg0aSJJSUlLKDTYNGzaUpAon0HAXIjIyMrRx48ZyJwz4qeqex/KUPm9Fbazo8dK23Hzzzbr55ps9akvDhg319NNPa/Lkybr//vt1//33KyUlRX369FFWVpYmTJjgPNeetNldjafK6j9VNDth6Sx2FV1Lb/ZZekwVLa+o/1S3L1emujWyqvK6tKGi9paGYXevs1atWmnz5s3lBmfb180TvqxPlpKSotq1a5e7LCYmRseOHfOqzQB8h4AFoMpKSkokSf3796906ucOHTqUeezIkSN6//33nb+vXbtWN954Y7nb33DDDdq2bZtGjBihe++9V+3bt1dMTIxq166tCxcuVPq/6xERFU+W6m5ZdZWOSLhT3fNoU2lbKho1uFTpLHHSj6NvgwcP1ltvvaVPP/1Un3/+uZYsWaIlS5Zo7ty5WrZsmTp16uRRG0pnfazqMsk317KyfVb1OavblytTt27dam1fldelDdVtb0VsXzdPVOdYSl97FfHlfQqAbxCwAFRZWlqapB/rqcyePbtK2xpjdPPNN2vv3r267rrrtHr1aj3yyCMaOHCgRo0a5bLujh07tGXLFiUmJmrJkiVlRps8mTbaF/Ly8ipcVjoFdrNmzSrdT3XOY0WaNm2q77//Xrt27So3lP102vRL27Jjxw5NmTJFN9xwQ5WeMzY21mXka8+ePZo5c6befPNNzZgxQ6tWraq0ze7aVtmyUBCsfblUVV6XvlbaH0pHVctTuszXRZNtqFOnjiTp1KlT5S4vnYYfQPjgv0UAVNmwYcMkSYsXL/ZopOZSDz/8sN5//321a9dOzz//vJ555hlnjZif/qFx9OhRSVJqamq5H+V7/vnnvTyC6tmyZYu2bNlS5vFt27Zp48aNzu9OVaY657EiAwYMkCS98MIL5S5/9tln3bbl1VdfrXYb0tLSNH/+fEnSpk2bKl0/MzNT9erV0+HDh/Xxxx+XWf7DDz9o2bJl1W5XIFWnL5f+gV7VGk1VUZXXpa8NHDhQkvTBBx/o4MGDZZZ/9dVX2rRpk8evs0ArDYE7duwod3np9x8BhA8CFoAqu/baa9WzZ0998cUXmjx5crnfDzp27JieeOIJlz8KV69erQceeED16tXT4sWLVb9+fY0YMUJ33323jh07phtvvFFFRUXO9du0aaNatWrp66+/LlOY9u2339Yjjzzis2N0xxijadOmuRQVPnHihKZNmyZjjLKzs52jU+54ex7dmTlzpmrVqqVXX31VS5YscVn28ssva+nSpeVud9tttyk9PV2LFy/WfffdV+7/thcUFDi/nyP9+IfuK6+8Um7R17fffluS68cJK1KvXj3deuutkqS77rrL5Y/qwsJCzZgxQ2fOnKl0P8GsOn25dDTU3Xe3qqOqr0tf69+/v3r37q1z587pl7/8pUuB6x9++EG//OUvJUnjxo3z6HUWaL169VJMTIy2b9+u5557zmXZ4sWL9dhjjwWoZQB8hYAFoMoiIiK0dOlSde3aVc8884wyMjLUr18/jR8/XtnZ2erWrZuaNGmiadOmOYPB4cOHNX78eF28eFGPP/64y8fX/vu//1t9+vTRF198oXvvvdf5eEJCgmbMmKGLFy9q0KBBGjhwoCZMmKDMzEyNGjVK99xzj9+PXfpxMoCCggK1bNlSo0ePVnZ2tlq2bKlPP/1UrVu31l/+8heP9uPNeaxM165dtWDBAl28eFGjR49Wnz59NHHiRPXq1Uvjx4/XnXfeWe529evX17vvvqsWLVpo4cKFat68uQYMGKCJEyfq+uuvV4cOHZSamuoyGcfu3bs1btw4NW7cWP3799f48eM1ZswYtW3bVg888IDq1KmjhQsXetTuhx56SJmZmdq6dasuu+wyXXvttRo7dqxatmyp5cuXKycnR9J/RnNCTXX6cnZ2tqQfZ4bMzs7WrbfeqltvvbVaMw6W8uZ16Q8vvvii0tPT9eabbyojI0NjxozRddddp1atWmn9+vXq3r27x6+zQKtbt65zRPcXv/iFrrjiCo0ZM0YdO3bU2LFj9Zvf/Mav7Tlw4ID69Onj/Pm///s/SdJbb73l8vjGjRv92i4gnBCwAHglNTVVa9eu1RNPPKFevXpp586deu211/TZZ59Jkm6//XZ9+OGHio6OVklJiW666Sbt379fOTk5mjRpksu+ateurVdeeUXx8fF69NFHXUZZHnnkEf3jH/9Qt27dtGHDBr333nuqV6+eXn75Zf3Xf/2XH4/4Pxo1aqS1a9dq7NixWr9+vd555x3Vr19fd9xxh9auXVvuFNAVqcp59NQ999yjN998U/3799fWrVv11ltvqXbt2nrttdd0xx13VLhdhw4dtGXLFi1cuFDt2rXTli1btHjxYq1bt07169fX7NmzXUbF+vTpo4cfflhXX3219u/fr7feeksfffSRatWqpenTp2vLli3lTi9dngYNGmjlypX67W9/q8TERH3wwQdavXq1Bg0apA0bNjin805ISPD4PAQbb/vytGnTtGDBAqWnp+u9997TP/7xD/3jH//QgQMHqtWe6rwufa1ly5bauHGj5syZo8aNG+udd97RsmXL1KpVKz388MP67LPP1KhRI7+1p7ruvPNOPfPMM+revbu++uorffTRR0pKStJHH32kW265xa9tKSws1Lp165w/pTMxHj582OXx6sxoCdR0DmPrg/8AEOYWLVqkyZMnKycnR4sWLQp0c2qMoqIidezYUd9++602bNig7t27B7pJAABUiBEsAEBQ2LBhQ5kpq0+fPq0ZM2bo22+/VefOnQlXAICgxzTtAICgkJ2drbNnz6pTp05KTEzUoUOHtGnTJh09elTx8fGMGgIAQgIjWACAoDBr1ix16NBB27dv15IlS5Sbm6vExETdcccd2rRpk7p16xboJgIAUCm+gwUAAAAAloT9CNbjjz+uFi1aKDo6Wr1799YXX3wR6CYBAAAACFNhHbBeeeUVzZo1S/PmzdPGjRvVpUsXDR06VIcOHQp00wAAAACEobD+iGDv3r3Vs2dPZzHCkpISpaWlaebMmR4V9ispKdH+/fvVsGFDORwOXzcXAAAAQJAyxujUqVNKTU1VRETF41RhO4vghQsXtGHDBs2ZM8f5WEREhAYPHqzc3NxytyksLFRhYaHz93379ql9+/Y+bysAAACA0LBnzx41a9aswuVhG7B++OEHXbx4UUlJSS6PJyUlaceOHeVus2DBAs2fP7/M4/01XJGq7ZN2AgAAAAh+xSrSZ3pPDRs2dLte2AYsb8yZM0ezZs1y/n7y5EmlpaUpUrUV6SBgAQAAADXW///Fqsq+OhS2ASshIUG1atXSwYMHXR4/ePCgkpOTy90mKipKUVFR/mgeAAAAgDAUtrMI1qlTR5mZmVq+fLnzsZKSEi1fvlx9+/YNYMsAAAAAhKuwHcGSpFmzZiknJ0c9evRQr1699Oijj+rMmTOaPHlyoJsGAAAAIAyFdcAaO3asDh8+rLlz56qgoEBdu3bVBx98UGbiCwAAAACwIazrYFXXyZMnFRsbq4G6lkkuAAAAgBqs2BRppd7UiRMnFBMTU+F6YfsdLAAAAADwNwIWAAAAAFhCwAIAAAAASwhYAAAAAGAJAQsAAAAALAnradrDyYf7N0mShqZ2DWg7AKCmK70fS/6/JwfyuYNZMLxH+uLacL2B0MQIFgAAAABYQsACAAAAAEsoNOwGhYYBAAAASBQaBgAAAAC/I2ABAAAAgCUELAAAAACwhIAFAAAAAJZQB8sSalXApmCo6RJuOKee41wBQPm4P4aWQP19zggWAAAAAFjCNO1uME07AAAAAIlp2gEAAADA7whYAAAAAGAJAQsAAAAALCFgAQAAAIAlTNNeTUzXCX+hr3mOc2UH5ScAoHLcK0OLP64XI1gAAAAAYAkBCwAAAAAsoQ6WG9TBAgAAACBRBwsAAAAA/I6ABQAAAACWELAAAAAAwBICFgAAAABYQh0s+I2/axNRlwK+QI0thBv6NErxvglfqIn9ihEsAAAAALCEgAUAAAAAllAHyw3qYAEAAACQqIMFAAAAAH5HwAIAAAAASwhYAAAAAGAJAQsAAAAALKEOVjVRPwT+Ql/zHOfKjppYuwQAqop7ZWjxx/ViBAsAAAAALCFgAQAAAIAl1MFygzpYAAAAACTqYAEAAACA3xGwAAAAAMASAhYAAAAAWELAAgAAAABLqIMFVAH1leBv1FepHs5fYHH+ESzC6f2b11XwYwQLAAAAACxhmnY3mKYdAAAAgMQ07QAAAADgdwQsAAAAALCEgAUAAAAAlhCwAAAAAMASpmkPMky9CQChI5BTP4fTtNP+Yus9NhDv1VxvIHQwggUAAAAAlhCwAAAAAMAS6mC5QR0sAAAAABJ1sAAAAADA7whYAAAAAGAJAQsAAAAALCFgAQAAAIAl1MEKEdS/AIDgEMh6hdRKLF8wvEf64tpwvYHQxAgWAAAAAFhCwAIAAAAAS6iD5QZ1sAAAAABI1MECAAAAAL8jYAEAAACAJQQsAAAAALCEgAUAAAAAllAHywNLvv1aMQ0jqEGBoEBdlPJxXjzHuQIA3wiGmmw1VTC9tzGCBQAAAACWELAAAAAAwBLqYLlBHSwAAAAAEnWwAAAAAMDvCFgAAAAAYAkBCwAAAAAsIWABAAAAgCXUwYJTMNUPgH8F8trT78IX9WAAcI8PPdy7q48RLAAAAACwhGna3WCadgAAAAAS07QDAAAAgN8RsAAAAADAEgIWAAAAAFhCwAIAAAAAS5imHeViWtXw5e/pV+lLuBT9AUB5uDcEN6ZurxpGsAAAAADAEgIWAAAAAFhCHSw3qIMFAAAAQKIOFgAAAAD4HQELAAAAACwhYAEAAACAJQQsAAAAALCEOliAF6jXAV+j5oh9vG6DF9cGNtWk+yevneDECBYAAAAAWELAAgAAAABLqIPlBnWwAAAAAEjUwQIAAAAAvyNgAQAAAIAlBCwAAAAAsISABQAAAACWUAfLC9QcgL/Q19zj/NjDuQQAz3HPDD3+rI/GCBYAAAAAWELAAgAAAABLqIPlBnWwAAAAAEjUwQIAAAAAvyNgAQAAAIAlBCwAAAAAsISABQAAAACWUAerCvw5fz5qHmpq2Mc5rRz3NQCwj/efwAr0exsjWAAAAABgCdO0u8E07QAAAAAkpmkHAAAAAL8jYAEAAACAJQQsAAAAALCEgAUAAAAAljBNOwI+lSWCi63+QL9CKaYrBlAR3iuCA/dpuxjBAgAAAABLCFgAAAAAYAl1sNygDhYAAAAAiTpYAAAAAOB3IRmwHnzwQTkcDpeftm3bOpefP39e06dPV+PGjdWgQQNlZ2fr4MGDAWwxAAAAgJogJAOWJHXo0EEHDhxw/nz22WfOZXfddZfefvttLV68WKtWrdL+/fs1evToALYWAAAAQE0QstO0R0ZGKjk5uczjJ06c0D/+8Q+9+OKLuuaaayRJTz/9tNq1a6e1a9eqT58+/m4qAAAAgBoiZAPWd999p9TUVEVHR6tv375asGCBmjdvrg0bNqioqEiDBw92rtu2bVs1b95cubm5BCxUC/U64G/UJqkezl9gcf4RLMLp/ZvXVfALyYDVu3dvLVq0SJdffrkOHDig+fPn68orr9TWrVtVUFCgOnXqKC4uzmWbpKQkFRQUuN1vYWGhCgsLnb+fPHnSF80HAAAAEKZCMmANGzbM+e/OnTurd+/eSk9P16uvvqq6det6vd8FCxZo/vz5NpoIAAAAoAYKmzpYPXv21ODBg/Wzn/1MgwYN0rFjx1xGsdLT03XnnXfqrrvuqnAf5Y1gpaWlUQcLAAAAqOFqVB2s06dP6/vvv1dKSooyMzNVu3ZtLV++3Ll8586dys/PV9++fd3uJyoqSjExMS4/AAAAAOCpkPyI4OzZszVy5Eilp6dr//79mjdvnmrVqqXx48crNjZWU6ZM0axZsxQfH6+YmBjNnDlTffv2ZYILAAAAAD4VkgFr7969Gj9+vI4cOaImTZqof//+Wrt2rZo0aSJJeuSRRxQREaHs7GwVFhZq6NCh+utf/xrgVgMAAAAId2HzHSxfOHnypGJjY/kOFgAAAFDDefodrJAcwYLvUWMhfPm7Fgh9CZeiPwAoD/eG4BZOdcT8ISwmuQAAAACAYEDAAgAAAABL+A6WG3wHCwAAAIBUw+pgAQAAAEAwIGABAAAAgCUELAAAAACwhIAFAAAAAJZQBwvwAvU64GvUHLGP123w4trAppp0/+S1E5wYwQIAAAAAS5im3Q2maQcAAAAgMU07AAAAAPgdAQsAAAAALCFgAQAAAIAlBCwAAAAAsIRp2gFLmCoVvlaTph72Bq/B0MB1gi+EW7/ifh/aGMECAAAAAEsIWAAAAABgCXWw3KAOFgAAAACJOlgAAAAA4HcELAAAAACwhIAFAAAAAJYQsAAAAADAEupgeWDJt18rpmEEtQgQFMKt1octnBfPca4AwDeoXxU4wfTexggWAAAAAFhCwAIAAAAAS6iD5QZ1sAAAAABI1MECAAAAAL8jYAEAAACAJQQsAAAAALCEgAUAAAAAllAHK4gF03z+AFCT+et+zH2/eoLl/PmyHcFyjAAqxggWAAAAAFhCwAIAAAAAS6iD5QZ1sAAAAABI1MECAAAAAL8jYAEAAACAJQQsAAAAALCEgAUAAAAAllAHq4YprZ9B7QxUhjou8Bf6A1Az8DdIcOHe6zuMYAEAAACAJUzT7gbTtAMAAACQmKYdAAAAAPyOgAUAAAAAlhCwAAAAAMASAhYAAAAAWELAAgAAAABLqINVBdRvgC9Rj8I+zmnluK8BgH28/wRWoN/bGMECAAAAAEuog+UGdbAAAAAASNTBAgAAAAC/I2ABAAAAgCUELAAAAACwhIAFAAAAAJYwTTsCyl/TaAZ6uk6ENqbbRU3DPTP8cV9DsAjHvsgIFgAAAABYQsACAAAAAEuog+UGdbAAAAAASNTBAgAAAAC/I2ABAAAAgCUELAAAAACwhIAFAAAAAJZQBwt+4++6KuFYVwGBR30ghBv6NErxvglfqIn9ihEsAAAAALCEgAUAAAAAllAHyw3qYAEAAACQqIMFAAAAAH5HwAIAAAAASwhYAAAAAGAJAQsAAAAALKEOFuCFmljTAf5FbSL7eN0GL64NbKpJ909eO8GJESwAAAAAsIRp2t1gmnYAAAAAEtO0AwAAAIDfEbAAAAAAwBICFgAAAABYQsACAAAAAEsIWAAAAABgCXWwLKEOAWyqSTU8/IVz6jnOFQCUj/tjaAnU3+eMYAEAAACAJdTBcoM6WAAAAAAk6mABAAAAgN8RsAAAAADAEgIWAAAAAFhCwAIAAAAAS5imHeVi2vnw5e8pZulLuBT9AUB5uDcEN6anrxpGsAAAAADAEgIWAAAAAFhCHSw3qIMFAAAAQKIOFgAAAAD4HQELAAAAACwhYAEAAACAJQQsAAAAALCEOlg1DHUM4Clf1iSh3gkuRX8Aagb+Bgku3Ht9hxEsAAAAALCEgAUAAAAAllAHyw3qYAEAAACQqIMFAAAAAH5HwAIAAAAASwhYAAAAAGAJAQsAAAAALKEOFmAJ9STga9SQcY/XYGjgOsEXwq1fcb8PbYxgAQAAAIAlTNPuBtO0AwAAAJCYph0AAAAA/I6ABQAAAACWELAAAAAAwBICFgAAAABYQsACAAAAAEuogwXrAlGLgnoR8Ldwq7kC0KdrLt5D4S81pa8xggUAAAAAllAHyw3qYAEAAACQqIMFAAAAAH5HwAIAAAAASwhYAAAAAGAJAQsAAAAALGGadviUL6f9ZUphBKOaMgUtagbus5C4r8G+cL+3MIIFAAAAAJYEZcBavXq1Ro4cqdTUVDkcDi1dutRluTFGc+fOVUpKiurWravBgwfru+++c1nn6NGjmjhxomJiYhQXF6cpU6bo9OnTfjwKAAAAADWNVx8RLCkp0fr167V8+XJt3LhRBw8e1LFjx9SoUSMlJSUpMzNT11xzjXr27KmIiKpnuDNnzqhLly665ZZbNHr06DLLFy5cqMcee0zPPPOMMjIy9MADD2jo0KHavn27oqOjJUkTJ07UgQMHtGzZMhUVFWny5Mm67bbb9OKLL3pzyPCSL4d9w3FIGaGPfolwQn+GRD+AfeHep6pUaPjQoUN66qmn9OSTT2r//v2SfhxNKrNTh0OSlJqaqttvv11Tp05VYmKidw10OLRkyRJdd911zudLTU3V3XffrdmzZ0uSTpw4oaSkJC1atEjjxo3TN998o/bt22v9+vXq0aOHJOmDDz7Q8OHDtXfvXqWmpnr03BQaBgAAACB5XmjYoxGswsJCLVy4UH/4wx909uxZRUZGKjMzU1dccYU6dOigxo0bKyYmRidOnNCRI0e0detWrVmzRlu2bNEDDzygBQsW6De/+Y3uueceRUVFVevA8vLyVFBQoMGDBzsfi42NVe/evZWbm6tx48YpNzdXcXFxznAlSYMHD1ZERITWrVun66+/vlptAAAAAIDyeBSwLr/8cuXn56tTp0665ZZbNHHiRCUkJFS63Q8//KDnnntOTz/9tObOnat//vOf+ve//12tBhcUFEiSkpKSXB5PSkpyLisoKCgzYhYZGan4+HjnOuUpLCxUYWGh8/eTJ09Wq60AAAAAahaPviBVt25dLV68WJs3b9avf/1rj8KVJCUkJOiuu+7Sli1b9Morr1R79MrXFixYoNjYWOdPWlpaoJsEAAAAIIR4NIK1bds2ryaruNSYMWOUnZ1drX1IUnJysiTp4MGDSklJcT5+8OBBde3a1bnOoUOHXLYrLi7W0aNHnduXZ86cOZo1a5bz95MnT9aokBXuNQlQsUBee/pd+KJ2DgDu8aGHe3f1eZSaqhuubO4nIyNDycnJWr58ufOxkydPat26derbt68kqW/fvjp+/Lg2bNjgXGfFihUqKSlR7969K9x3VFSUYmJiXH4AAAAAwFM+r4O1bNmyKm9z+vRpbdq0SZs2bZL048QWmzZtUn5+vhwOh+688079/ve/11tvvaWvv/5av/jFL5SamuqcabBdu3bKysrS1KlT9cUXX+jzzz/XjBkzNG7cOI9nEAQAAACAqqrSNO1V8cknn2jevHlas2aNiouLq7TtypUrdfXVV5d5PCcnR4sWLZIxRvPmzdNTTz2l48ePq3///vrrX/+qNm3aONc9evSoZsyYobffflsRERHKzs7WY489pgYNGnjcDqZpBwAAACB5Pk17lQJWYWGhcnNzdfDgQSUlJalv375lJq74/PPP9cADD2jVqlUyxig6Olpnz571/kgCiIAFAAAAQPI8YHn8EcGlS5eqefPmGjRokCZMmKBBgwapRYsW+uCDDyRJx48f17hx43TVVVdp5cqVcjgc+sUvfqEdO3ZU/2gAAAAAIAR4NIvg1q1bdeONN5b5qN/Bgwd1ww03aN26dRozZox27twpY4xGjRql//7v/1b79u190mgAAAAACEYejWA9+uijKi4u1hVXXKHPP/9cp06d0r59+/Tkk0+qdu3auuaaa7Rjxw6lpKTo448/1tKlSwlXAAAAAGocj0awVq9erUaNGuntt99Wo0aNJEn169fX1KlTFRERoalTpyoyMlIrVqxwmWgCwYu6FAhEH6C2Bi5FfwBqJv4GCQ1cJ+95NIK1b98+9erVyxmuLjVixAhJUv/+/QlXAAAAAGo0j0awzp07p5SUlHKXJSUlSZLS0tLstQo+x/9EIBB9gH6HS9EfgJqJ135o4Dp5z1qh4Vq1atnaFQAAAACEJI9GsCTp9OnTys/P92p58+bNq94yAAAAAAgxHhUajoiIkMPh8O4JHI4y07uHCgoNAwAAAJA8LzTs8QiWBznM6nYAAAAAEGo8Clh5eXm+bgcAAAAAhDyPAlZ6erqv24EawN81b6jfAF+gdhPCDX0apXjfhC/UxH7l0SyC11xzjRYuXOjrtgAAAABASPN4kotJkybpn//8pz/aFDSY5AIAAACA5PkkF9bqYAEAAABATUfAAgAAAABLCFgAAAAAYAkBCwAAAAAs8XiSC4fD4d0TOBwqLi72attAY5IL3/PX9MBMQ4zqqIlTzKJm454Z/rivIViEUl/0dJILj+pgSZIHOQwAAAAAajSPA1ZWVpbuu+8+X7YFAAAAAEIadbDc4COCAAAAACTqYAEAAACA3xGwAAAAAMASAhYAAAAAWELAAgAAAABLPJpFsKSkxNftQDlCqS4AAIQzf92Pue9XT7CcP1+2I1iOEUDFPBrBOnfunJUns7UfAAAAAAhGHgWsVq1a6YknntDFixe9epLi4mI9/vjjatWqlVfbAwAAAEAo8KgOVo8ePbRx40Y1bdpUOTk5ysnJUevWrSvd+c6dO7Vo0SI999xz2r9/vzIzM7V+/XorDfcH6mABAAAAkDyvg+VRwDLG6P/+7/90//336/Dhw3I4HGrWrJn69u2rdu3aqXHjxoqJidHJkyd15MgRbd++Xbm5udq3b5+MMWrSpIkeeughTZkyRQ6Hw+qB+hIBCwAAAIBkOWCVOn/+vJ577jn95S9/0ddff/3jDsoJTKW77Ny5s2bMmKGJEyeqbt26VT2GgCNgAQAAAJB8FLAutWvXLq1YsUJfffWVDh48qBMnTiguLk6JiYnq3r27rr76arVo0cLb9gcFAhYAAAAAyfOA5dE07eVp0aKFbrnlFm83BwAAAICw43XAgn+V1r2g5gUABFYg6xBRA6l8wfAe6Ytrw/UGQpNH07QDAAAAACrn9XewagK+gwUAAABA8vw7WIxgAQAAAIAlBCwAAAAAsISABQAAAACWELAAAAAAwBICFgAAAABYYqUO1oULF3TkyBFFRUUpPj7exi6BkBEM9VdQs1AbxxWvwdDFtYO/hfL9k9dL6KjWCNbzzz+vXr16qX79+mrWrJlmz57tXLZkyRJNmDBBeXl51W4kAAAAAIQCr0ewbr31Vj399NMyxqhBgwY6ffq0y/I2bdro5ZdfVvfu3V2CFxBu+J8k+Bt9zhXnI3Rx7eBvodznQrntNY1XI1gvvPCC/vnPf6pjx45av369Tpw4UWadDh06qFmzZnr//fer3UgAAAAACAVejWA99dRTatCggd555x2lpaVVuF6nTp30zTffeN04AAAAAAglXo1gbd68Wb1793YbriQpPj5eBw8e9KphAAAAABBqvApYhYWFio2NrXS9w4cPq1atWt48BQAAAACEHK8+Iti0adNKP/pnjNH27duVkZHhVcPgW6E8TSnsCEQfYIpZXIr+ANRM/A0SGrhO3vNqBGvQoEHasWOH3nzzzQrXee6557R371797Gc/87pxAAAAABBKvApYs2fPVlRUlCZMmKBHH31U+/fvdy47evSonnjiCf3qV79S/fr1dccdd1hrLAAAAAAEM4cxxniz4eLFi/WLX/xCFy5cKHd57dq19cILLyg7O7taDQykkydPKjY2VgN1rSIdtQPdHAAAAAABUmyKtFJv6sSJE4qJialwPa9GsCRpzJgxWr9+vcaMGaOGDRvKGCNjjKKjozVy5Ejl5uaGdLgCAAAAgKryapKLUh07dtTLL78sY4yOHDmikpISJSQkKCLC69wGAAAAACGrWgGrlMPhUEJCgo1dAQAAAEDIYqgJAAAAACzxegSruLhYixcv1vLly7V//36dP3++3PUcDoeWL1/udQOBUEG9CPgadaPc4zUYGrhO8IVw61fc70ObVwHr8OHDGjJkiLZs2aLKJiF0OBxeNQwAAAAAQo1XAevee+/V5s2bddlll2natGlq3bq1GjZsaLttAAAAABBSvKqD1aRJE0VGRmrbtm2Kj4/3RbuCAnWwAAAAAEg+roN17tw59evXL6zDFQAAAABUlVcBq3Xr1jp37pzttgAAAABASPMqYE2ZMkUrV67U3r17bbcHAAAAAEKWVwFrxowZGjFihK655hp9+OGHKikpsd0uAAAAAAg5XtfBevLJJzVgwAANHz5ckZGRSklJUURE2bzmcDj0/fffV6uR8C1qLeBStvoD/Qqlwq0+DQB7eK8IDtyn7fIqYO3Zs0dXXnml9uzZI2OMioqKlJ+fX+661MECAAAAUFN4NU37hAkT9PLLL6t///6aNWuWWrdurQYNGlS4fnp6erUaGShM0w4AAABA8nyadq9GsD7++GOlp6dr2bJlioqK8rqRAAAAABBOvK6D1atXL8IVAAAAAFzCq4DVvn17HT161HZbAAAAACCkeRWwZs6cqVWrVmnr1q222wMAAAAAIcurgHXTTTdp9uzZuuaaa/Tkk09WOIMgAAAAANQkXk1yUatWLee/f/WrX7ld1+FwqLi42JunQYgKRC0F6mjA36gZgnBDn665eA+Fv9SUvuZVwKrKzO5ezAIPAAAAACHJqzpYNQV1sAAAAABIntfB8uo7WAAAAACAsghYAAAAAGAJAQsAAAAALPFokouWLVvK4XDo448/VkZGhlq2bOnxEzgcDn3//fdeNxAAAAAAQoVHAWvXrl1yOBwqKipy/u4ph8PhVcMQvnw5FTDTDCMQ6HcINfRZVIY+gkAIl2ncPQpYeXl5kqSmTZu6/A4AAAAA+A+PAlZ6errb3wEAAAAAXtbBWr16tZKTk9WmTRu363333Xc6cOCArrrqKq8bGEjUwQIAAAAg+bgO1sCBA/WHP/yh0vUWLlyoq6++2punAAAAAICQ4/U07V4MfAEAAABAWPNpHaxjx44pOjral08BAAAAAEHDo0kuJCk/P9/l99OnT5d5rFRxcbG2bdumjz76SK1atapeCwEAAAAgRHgcsFq0aOFS0+r111/X66+/7nYbY4xuuukm71sXQqgXAZvCpQ5EMOGceo5zBQDl4/4YWgL197nHAat58+bOgJWfn6969eopISGh3HXr1KmjZs2aKTs7W9OmTbPTUgAAAAAIch4HrF27djn/HRERoTFjxuif//ynL9oEAAAAACHJqzpYzzzzjC677DL169fPF20KGtTBAgAAACB5XgfL4xGsS+Xk5HjdMAAAAAAIVz6dph0AAAAAahICFgAAAABYQsACAAAAAEu8+g5WTUfNK/gLfc09zo89nEsA8Bz3zNDjzxpmjGABAAAAgCVeTdNeUzBNOwAAAADJ82naGcECAAAAAEsIWAAAAABgCQELAAAAACwhYAEAAACAJQQsAAAAALCEOlhBjBoLABAc/HU/5r5fPcFy/nzZjmA5RgAVYwQLAAAAACyhDpYb1MECAAAAIFEHCwAAAAD8joAFAAAAAJYQsAAAAADAEgIWAAAAAFjCNO1AJZgSF/5CX7On9FxyHoMH1wT+Fg731HA4hpqIESwAAAAAsISABQAAAACWUAfLDepgAQAAAJCogwUAAAAAfkfAAgAAAABLCFgAAAAAYAkBCwAAAAAsCcqAtXr1ao0cOVKpqalyOBxaunSpy/JJkybJ4XC4/GRlZbmsc/ToUU2cOFExMTGKi4vTlClTdPr0aT8ehW98uH+T8wcAEBx8cW/mXl89/nq/DOR1oo8AwSkoA9aZM2fUpUsXPf744xWuk5WVpQMHDjh/XnrpJZflEydO1LZt27Rs2TK98847Wr16tW677TZfNx0AAABADRYZ6AaUZ9iwYRo2bJjbdaKiopScnFzusm+++UYffPCB1q9frx49ekiS/vznP2v48OH64x//qNTUVOttBgAAAICgDFieWLlypRITE9WoUSNdc801+v3vf6/GjRtLknJzcxUXF+cMV5I0ePBgRUREaN26dbr++uvL3WdhYaEKCwudv588edK3B+GFoaldA90EAMBP+OLezP2+evx1/gJ5negjQHAKyo8IViYrK0vPPvusli9frj/84Q9atWqVhg0bposXL0qSCgoKlJiY6LJNZGSk4uPjVVBQUOF+FyxYoNjYWOdPWlqaT48DAAAAQHgJyRGscePGOf/dqVMnde7cWa1atdLKlSs1aNAgr/c7Z84czZo1y/n7yZMnCVkAAAAAPBaSI1g/1bJlSyUkJOhf//qXJCk5OVmHDh1yWae4uFhHjx6t8Htb0o/f64qJiXH5AQAAAABPhUXA2rt3r44cOaKUlBRJUt++fXX8+HFt2LDBuc6KFStUUlKi3r17B6qZAAAAAMJcUH5E8PTp087RKEnKy8vTpk2bFB8fr/j4eM2fP1/Z2dlKTk7W999/r3vvvVeXXXaZhg4dKklq166dsrKyNHXqVD3xxBMqKirSjBkzNG7cOGYQhHWlNUj4sjH85dK6N/Q7XoOhjGsHfwvl+yevl9ARlCNYX375pbp166Zu3bpJkmbNmqVu3bpp7ty5qlWrlrZs2aJRo0apTZs2mjJlijIzM/Xpp58qKirKuY8XXnhBbdu21aBBgzR8+HD1799fTz31VKAOCQAAAEAN4DDGmEA3IlidPHlSsbGxGqhrFemoHejmAAAAAAiQYlOklXpTJ06ccDtXQ1COYAEAAABAKCJgAQAAAIAlBCwAAAAAsISABQAAAACWELAAAAAAwJKgrIOFioVy/QYACFe+uDdT86Z6/PV+GcjrRB8BghMjWAAAAABgCXWw3KAOFgAAAACJOlgAAAAA4HcELAAAAACwhIAFAAAAAJYQsAAAAADAEqZphxNTwNdcgbz29LvwxRTSALjHhx7u3dXHCBYAAAAAWELAAgAAAABLqIPlBnWwAAAAAEjUwQIAAAAAvyNgAQAAAIAlBCwAAAAAsISABQAAAACWUAcrSFBzAADCg+37OXWEqs/WNfHHezXXGwh9jGABAAAAgCUELAAAAACwhDpYblAHCwAAAIBEHSwAAAAA8DsCFgAAAABYQsACAAAAAEsIWAAAAABgCXWw4He+rPFB/RAEAv0OoYY+i8rQRxAI4VIXlhEsAAAAALCEadrdYJp2AAAAABLTtAMAAACA3xGwAAAAAMASAhYAAAAAWELAAgAAAABLCFgAAAAAYAl1sDyw5NuvFdMwIuTn5Ed4oDZJ+TgvnuNcAYBvhEsdp1AUTO9tjGABAAAAgCXUwXKDOlgAAAAAJOpgAQAAAIDfEbAAAAAAwBICFgAAAABYQsACAAAAAEuYpt0LwTQNJMIbfc09zo89nEsA8Bz3zNDjzyn0GcECAAAAAEsIWAAAAABgCXWw3KAOFgAAAACJOlgAAAAA4HcELAAAAACwhIAFAAAAAJYQsAAAAADAEupgBRnqKgBA6PBnXZVgeu5QZes9NhDv1VxvIHQwggUAAAAAlhCwAAAAAMAS6mC5QR0sAAAAABJ1sAAAAADA7whYAAAAAGAJAQsAAAAALCFgAQAAAIAl1MGCddQHQU1AzTqEG/p0zcV7KPylpvQ1RrAAAAAAwBKmaXeDadoBAAAASEzTDgAAAAB+R8ACAAAAAEsIWAAAAABgCQELAAAAACwhYAEAAACAJdTBAipBbRj4C33NnppSayWUcE3gb+FwTw2HY6iJGMECAAAAAEuog+UGdbAAAAAASNTBAgAAAAC/I2ABAAAAgCUELAAAAACwhIAFAAAAAJYwTXsNxbSfCEQfYJpmXIr+ANRM/A0SGrhO3mMECwAAAAAsIWABAAAAgCXUwXKDOlgAAAAAJOpgAQAAAIDfEbAAAAAAwBICFgAAAABYQsACAAAAAEuog1XDUHcGnvJl/Qtqa+BS9AegZuBvkODCvdd3GMECAAAAAEsIWAAAAABgCXWw3KAOFgAAAACJOlgAAAAA4HcELAAAAACwhIAFAAAAAJYQsAAAAADAEupgBQlqQwBAeLB9P6dWTfXZuib+eK/megOhjxEsAAAAALCEgAUAAAAAllAHyw3qYAEAAACQqIMFAAAAAH5HwAIAAAAASwhYAAAAAGAJAQsAAAAALKEOFvzOlzU+qB+CQKDfIdTQZ1EZ+ggCIVzqwjKCBQAAAACWME27G0zTDgAAAEBimnYAAAAA8DsCFgAAAABYQsACAAAAAEsIWAAAAABgCdO0hximTQWA4OOLe3O4TFccKP56vwzkdaKPAMGJESwAAAAAsISABQAAAACWUAfLDepgAQAAAJCogwUAAAAAfkfAAgAAAABLCFgAAAAAYAkBCwAAAAAsoQ5WkKCWBQCEB9v3c+ofVp+ta+KP92quNxD6GMECAAAAAEsIWAAAAABgCXWw3KAOFgAAAACJOlgAAAAA4HdBGbAWLFignj17qmHDhkpMTNR1112nnTt3uqxz/vx5TZ8+XY0bN1aDBg2UnZ2tgwcPuqyTn5+vn//856pXr54SExN1zz33qLi42J+HAgAAAKAGCcqAtWrVKk2fPl1r167VsmXLVFRUpCFDhujMmTPOde666y69/fbbWrx4sVatWqX9+/dr9OjRzuUXL17Uz3/+c124cEFr1qzRM888o0WLFmnu3LmBOCQAAAAANUBIfAfr8OHDSkxM1KpVq3TVVVfpxIkTatKkiV588UXdcMMNkqQdO3aoXbt2ys3NVZ8+ffT+++9rxIgR2r9/v5KSkiRJTzzxhO677z4dPnxYderUqfR5+Q4WAAAAAMnz72CFRB2sEydOSJLi4+MlSRs2bFBRUZEGDx7sXKdt27Zq3ry5M2Dl5uaqU6dOznAlSUOHDtW0adO0bds2devWrczzFBYWqrCw0Pn7yZMnfXVICFHUK4O/UROnejh/gcX5R7AIp/dvXlfBLyg/InipkpIS3XnnnerXr586duwoSSooKFCdOnUUFxfnsm5SUpIKCgqc61warkqXly4rz4IFCxQbG+v8SUtLs3w0AAAAAMJZ0Aes6dOna+vWrXr55Zd9/lxz5szRiRMnnD979uzx+XMCAAAACB9B/RHBGTNm6J133tHq1avVrFkz5+PJycm6cOGCjh8/7jKKdfDgQSUnJzvX+eKLL1z2VzrLYOk6PxUVFaWoqCjLR4FwwlA8/I0+Vz2cv8Di/CNYhFNfDKdjCVdBOYJljNGMGTO0ZMkSrVixQhkZGS7LMzMzVbt2bS1fvtz52M6dO5Wfn6++fftKkvr27auvv/5ahw4dcq6zbNkyxcTEqH379v45EAAAAAA1SlCOYE2fPl0vvvii3nzzTTVs2ND5nanY2FjVrVtXsbGxmjJlimbNmqX4+HjFxMRo5syZ6tu3r/r06SNJGjJkiNq3b6+bb75ZCxcuVEFBge6//35Nnz6dUSoAAAAAPhGU07Q7HI5yH3/66ac1adIkST8WGr777rv10ksvqbCwUEOHDtVf//pXl4//7d69W9OmTdPKlStVv3595eTk6OGHH1ZkpGe5kmnaAQAAAEieT9MelAErWBCwAAAAAEhhVgcLocuXtRqoA4FgFE61VgDus5C4r8G+cL+3BOUkFwAAAAAQiviIoBt8RBAAAACA5PlHBBnBAgAAAABLCFgAAAAAYAkBCwAAAAAsIWABAAAAgCVM0w6mX4ULW/2BfoVS4T4dLwDv8V4RHLhP28UIFgAAAABYQsACAAAAAEuog+UGdbAAAAAASNTBAgAAAAC/I2ABAAAAgCUELAAAAACwhIAFAAAAAJZQByvIUIcAAEJHIGv4UD+o6my9xwbivZrrDYQORrAAAAAAwBICFgAAAABYQh0sN6iDBQAAAECiDhYAAAAA+B0BCwAAAAAsIWABAAAAgCUELAAAAACwhDpYQDVRmwT+Rr08V7wGQxfXDv4WyvdPXi+hgxEsAAAAALCEgAUAAAAAllAHyw3qYAEAAACQqIMFAAAAAH5HwAIAAAAASwhYAAAAAGAJAQsAAAAALKEOVhVQfwC+FMq1OYIV57Ry3NcAwD7efwIr0O9tjGABAAAAgCVM0+4G07QDAAAAkJimHQAAAAD8joAFAAAAAJYQsAAAAADAEgIWAAAAAFjCNO3VFOhpIFFz0Nc8x7myg2mGAaBy3CtDiz+uFyNYAAAAAGAJAQsAAAAALKEOlhvUwQIAAAAgUQcLAAAAAPyOgAUAAAAAlhCwAAAAAMASAhYAAAAAWEIdLPiUL2sNUHcCwYgaXAgn3GchcV+DfeF+b2EECwAAAAAsIWABAAAAgCXUwXKDOlgAAAAAJOpgAQAAAIDfEbAAAAAAwBICFgAAAABYQsACAAAAAEuog4WA8ldtDWp4oDrCvV4H8FPcM8Mf9zUEi3Dsi4xgAQAAAIAlBCwAAAAAsIQ6WG5QBwsAAACARB0sAAAAAPA7AhYAAAAAWELAAgAAAABLCFgAAAAAYAl1sIBKhGN9BgQn+po91HEKPlwT+Fs43FPD4RhqIkawAAAAAMASpml3g2naAQAAAEhM0w4AAAAAfkfAAgAAAABLCFgAAAAAYAkBCwAAAAAsIWABAAAAgCUELAAAAACwhIAFAAAAAJYQsAAAAADAEgIWAAAAAFhCwAIAAAAASwhYAAAAAGAJAQsAAAAALCFgAQAAAIAlBCwAAAAAsISABQAAAACWELAAAAAAwBICFgAAAABYQsACAAAAAEsIWAAAAABgSWSgGxDMjDGSpGIVSSbAjQEAAAAQMMUqkvSfjFARApYbp06dkiR9pvcC3BIAAAAAweDUqVOKjY2tcLnDVBbBarCSkhLt3LlT7du31549exQTExPoJiEATp48qbS0NPpADUYfAH0AEv0A9IGazhijU6dOKTU1VRERFX/TihEsNyIiItS0aVNJUkxMDC+kGo4+APoA6AOQ6AegD9Rk7kauSjHJBQAAAABYQsACAAAAAEsIWJWIiorSvHnzFBUVFeimIEDoA6APgD4AiX4A+gA8wyQXAAAAAGAJI1gAAAAAYAkBCwAAAAAsIWABAAAAgCUELAAAAACwhIDlxuOPP64WLVooOjpavXv31hdffBHoJsFHHnzwQTkcDpeftm3bOpefP39e06dPV+PGjdWgQQNlZ2fr4MGDAWwxbFi9erVGjhyp1NRUORwOLV261GW5MUZz585VSkqK6tatq8GDB+u7775zWefo0aOaOHGiYmJiFBcXpylTpuj06dN+PApUR2V9YNKkSWXuDVlZWS7r0AdC14IFC9SzZ081bNhQiYmJuu6667Rz506XdTy5/+fn5+vnP/+56tWrp8TERN1zzz0qLi7256GgGjzpBwMHDixzL7j99ttd1qEfoBQBqwKvvPKKZs2apXnz5mnjxo3q0qWLhg4dqkOHDgW6afCRDh066MCBA86fzz77zLnsrrvu0ttvv63Fixdr1apV2r9/v0aPHh3A1sKGM2fOqEuXLnr88cfLXb5w4UI99thjeuKJJ7Ru3TrVr19fQ4cO1fnz553rTJw4Udu2bdOyZcv0zjvvaPXq1brtttv8dQiopsr6gCRlZWW53Bteeukll+X0gdC1atUqTZ8+XWvXrtWyZctUVFSkIUOG6MyZM851Krv/X7x4UT//+c914cIFrVmzRs8884wWLVqkuXPnBuKQ4AVP+oEkTZ061eVesHDhQucy+gFcGJSrV69eZvr06c7fL168aFJTU82CBQsC2Cr4yrx580yXLl3KXXb8+HFTu3Zts3jxYudj33zzjZFkcnNz/dRC+Joks2TJEufvJSUlJjk52fzP//yP87Hjx4+bqKgo89JLLxljjNm+fbuRZNavX+9c5/333zcOh8Ps27fPb22HHT/tA8YYk5OTY6699toKt6EPhJdDhw4ZSWbVqlXGGM/u/++9956JiIgwBQUFznX+9re/mZiYGFNYWOjfA4AVP+0HxhgzYMAA8+tf/7rCbegHuBQjWOW4cOGCNmzYoMGDBzsfi4iI0ODBg5WbmxvAlsGXvvvuO6Wmpqply5aaOHGi8vPzJUkbNmxQUVGRS39o27atmjdvTn8IY3l5eSooKHC57rGxserdu7fzuufm5iouLk49evRwrjN48GBFRERo3bp1fm8zfGPlypVKTEzU5ZdfrmnTpunIkSPOZfSB8HLixAlJUnx8vCTP7v+5ubnq1KmTkpKSnOsMHTpUJ0+e1LZt2/zYetjy035Q6oUXXlBCQoI6duyoOXPm6OzZs85l9ANcKjLQDQhGP/zwgy5evOjyIpGkpKQk7dixI0Ctgi/17t1bixYt0uWXX64DBw5o/vz5uvLKK7V161YVFBSoTp06iouLc9kmKSlJBQUFgWkwfK702pZ3HyhdVlBQoMTERJflkZGRio+Pp2+EiaysLI0ePVoZGRn6/vvv9dvf/lbDhg1Tbm6uatWqRR8IIyUlJbrzzjvVr18/dezYUZI8uv8XFBSUe58oXYbQUl4/kKQJEyYoPT1dqamp2rJli+677z7t3LlTb7zxhiT6AVwRsABJw4YNc/67c+fO6t27t9LT0/Xqq6+qbt26AWwZgEAaN26c89+dOnVS586d1apVK61cuVKDBg0KYMtg2/Tp07V161aX79+i5qmoH1z6vcpOnTopJSVFgwYN0vfff69WrVr5u5kIcnxEsBwJCQmqVatWmVmCDh48qOTk5AC1Cv4UFxenNm3a6F//+peSk5N14cIFHT9+3GUd+kN4K7227u4DycnJZSa+KS4u1tGjR+kbYaply5ZKSEjQv/71L0n0gXAxY8YMvfPOO/rkk0/UrFkz5+Oe3P+Tk5PLvU+ULkPoqKgflKd3796S5HIvoB+gFAGrHHXq1FFmZqaWL1/ufKykpETLly9X3759A9gy+Mvp06f1/fffKyUlRZmZmapdu7ZLf9i5c6fy8/PpD2EsIyNDycnJLtf95MmTWrdunfO69+3bV8ePH9eGDRuc66xYsUIlJSXON1+El7179+rIkSNKSUmRRB8IdcYYzZgxQ0uWLNGKFSuUkZHhstyT+3/fvn319ddfuwTtZcuWKSYmRu3bt/fPgaBaKusH5dm0aZMkudwL6AdwCvQsG8Hq5ZdfNlFRUWbRokVm+/bt5rbbbjNxcXEus8MgfNx9991m5cqVJi8vz3z++edm8ODBJiEhwRw6dMgYY8ztt99umjdvblasWGG+/PJL07dvX9O3b98AtxrVderUKfPVV1+Zr776ykgy//u//2u++uors3v3bmOMMQ8//LCJi4szb775ptmyZYu59tprTUZGhjl37pxzH1lZWaZbt25m3bp15rPPPjOtW7c248ePD9QhoYrc9YFTp06Z2bNnm9zcXJOXl2c+/vhj0717d9O6dWtz/vx55z7oA6Fr2rRpJjY21qxcudIcOHDA+XP27FnnOpXd/4uLi03Hjh3NkCFDzKZNm8wHH3xgmjRpYubMmROIQ4IXKusH//rXv8zvfvc78+WXX5q8vDzz5ptvmpYtW5qrrrrKuQ/6AS5FwHLjz3/+s2nevLmpU6eO6dWrl1m7dm2gmwQfGTt2rElJSTF16tQxTZs2NWPHjjX/+te/nMvPnTtnfvWrX5lGjRqZevXqmeuvv94cOHAggC2GDZ988omRVOYnJyfHGPPjVO0PPPCASUpKMlFRUWbQoEFm586dLvs4cuSIGT9+vGnQoIGJiYkxkydPNqdOnQrA0cAb7vrA2bNnzZAhQ0yTJk1M7dq1TXp6upk6dWqZ/2ijD4Su8q69JPP000871/Hk/r9r1y4zbNgwU7duXZOQkGDuvvtuU1RU5Oejgbcq6wf5+fnmqquuMvHx8SYqKspcdtll5p577jEnTpxw2Q/9AKUcxhjjv/EyAAAAAAhffAcLAAAAACwhYAEAAACAJQQsAAAAALCEgAUAAAAAlhCwAAAAAMASAhYAAAAAWELAAgAAAABLCFgAgBqvRYsWcjgc2rVrl8vjAwcOlMPh0MqVK6u8z+psCwAIXQQsAACq6MEHH5TD4dCDDz4Y6KYAAIJMZKAbAABAsHr22Wd19uxZNW/e3K/bAgBCFwELAIAKVCccEawAoGbiI4IAAGvOnj2rRx99VP3791ejRo0UFRWl9PR0jRw5Ui+++GKZdR9++GF1795dDRs2VL169dShQwfdf//9OnbsWJl979q1Sw6HQy1atJAxRk899ZQyMzNVv359xcbGasiQIcrNza2wbdu3b9eYMWOUkJCgunXrqmPHjvrjH/+oixcvVrhNed+jcjgcmj9/viRp/vz5cjgczp9Jkya53bZUcXGxnnjiCV1xxRWKjY1VdHS0WrdurTvuuEP79u0rty2lzyFJr7/+uvr376+YmBjVr19f/fr103vvvVfudgcOHNCvf/1rtWnTRtHR0apXr57S0tI0aNAg/fGPf6zw2AEA3nEYY0ygGwEACH179uxRVlaWtm/frnr16qlfv35q3Lix9u3bpy1btiguLs45icTRo0c1aNAgbdq0STExMRo4cKBq166tVatW6YcfflBGRoZWrFihFi1aOPe/a9cuZWRkKD09XQMHDtSLL76oK6+8UgkJCdq0aZO+/fZbRUVFadWqVerdu7dL2z777DNlZWXpzJkzatmypXr16qUffvhBq1at0qhRo/Tll19q9+7dysvLc3nOgQMHatWqVfrkk080cOBASdKkSZO0adMmbd68WV26dFHXrl2d6/fv31+33nprhdtKUmFhoUaMGKGPP/5Y0dHRuvrqqxUTE6M1a9Zoz549SkhI0Icffqju3bu7HENpuJo7d67+67/+S1dccYWaNWumHTt2aPPmzXI4HHr99dd1/fXXO7cpKChQZmam9u/fr+bNm6tbt26Kjo7W/v37tW3bNl28eFHHjx/37oIDAMpnAACoposXL5oePXoYSWbIkCHm0KFDLsvPnTtn3n33XefvY8eONZJM7969zQ8//OB8/NSpU2bYsGFGkrniiitc9pGXl2ckGUkmPT3d7Ny507msuLjY3HLLLc7n/+lzp6WlGUnmzjvvNMXFxc5lmzdvNgkJCc795uXluWw7YMAAI8l88sknLo/PmzfPSDLz5s2r8JxUtO19991nJJlWrVq5PN+FCxfMlClTjCSTkZFhCgsLXbYrbWNcXJxZu3Ztue1p06aNy+Pz5883ksxtt91mSkpKXJZduHDBfPzxxxW2HwDgHT4iCACotrfffltffvmlUlJS9Prrr6tJkyYuy6OjozV8+HBJUn5+vhYvXiyHw6GnnnpKjRs3dq7XoEED/f3vf1d0dLTWrFmjNWvWlPt8f/7zn9WmTRvn77Vq1dJDDz0kSVq1apWKioqcy15//XXt2bNHaWlpWrhwoWrVquVc1rlzZ/2///f/qn8CPHT+/Hk9/vjjkqRHHnnEZbSsdu3aeuyxx5SUlKS8vDy99tpr5e7jd7/7XZkRujlz5ig2Nlbffvut9uzZ43z84MGDkqSsrCznCNilzzdo0CAbhwUAuAQBCwBQbR988IEkacKECWrQoIHbdVevXq2SkhJ169ZNnTt3LrO8adOmGjp0qCTpk08+KbM8MjJSWVlZZR5PTk5Wo0aNVFhYqCNHjjgfL/0O1I033qjatWuX2S4nJ8dte2368ssvdfr0acXHx2vkyJFllterV0/jxo2TVP6xSyp3u6ioKLVs2VKSXL7D1atXL0nSb37zG73xxhs6ffp0tY8BAOAeAQsAUG27d++WJLVt27bSdUsDQEZGRoXrtGrVymXdS6WkpJQblCQpJiZG0o8jRaX27t3r9vkaNWqk2NjYStttQ3WPXap4dsLyjv3mm2/WxIkT9e233yo7O1txcXHq3LmzfvWrX2nFihVeHQMAwD0CFgAgpERE1Oy3rqocf0REhJ5//nlt27ZNCxcu1IgRI3TgwAH97W9/06BBgzRq1Ci3sygCAKquZr9LAQCsKB1V2bFjR6XrNm3aVJL073//u8J1SpeVrlsdpfsoncHwp44fP64TJ05U+3mq0pa8vLwK17F57KXat2+ve+65R0uXLtWhQ4f08ccfKzExUW+//baeffZZa88DACBgAQAsKP1O1EsvvaQzZ864Xfeqq65SRESEc6rznzpw4IDzO11XX311tds2YMAASdKrr77qMvlFKW8CRp06dST9WM+qKnr06KEGDRro6NGjeuutt8osP3funF5++WVJdo69PA6HQ4MGDdKECRMkSZs2bfLJ8wBATUXAAgBU26hRo9StWzft379fY8aMcZlkQvrxe0Hvv/++pB9Hu8aMGSNjjH75y1+6rHvmzBnddtttOn/+vK644gpdccUV1W7bDTfcoKZNmyo/P19z5sxRSUmJc9nWrVv1+9//vsr7bNasmSRp27ZtVdouOjpa06dPlyTdfffdzu+uSVJRUZF+/etfq6CgQBkZGbrhhhuq3K6fevbZZ7Vhw4Yyj586dco5+Ud6enq1nwcA8B+RgW4AACD0RUREaMmSJRo6dKjef/99NW/eXP3793cWGt68ebNLoeHHH39cO3bs0Lp169SqVStdffXVioyM1KpVq3T48GFlZGTohRdesNK2unXr6oUXXtDw4cP1pz/9SUuXLlXPnj115MgRrVy5UiNHjtSGDRtcwk5lhg4dqvr162vp0qXq37+/WrdurVq1aqlfv36aPHmy223nz5+vL7/8UsuXL1e7du109dVXq2HDhsrNzVV+fr4aN26sxYsXO0fJquONN95QTk6OUlNT1bVrVzVq1EjHjh3T559/rhMnTqhjx46aOnVqtZ8HAPAfBCwAgBXp6en68ssv9de//lWvvfaacnNzdeHCBSUnJ2vAgAHOj6RJUuPGjbVmzRo99thjeuWVV/TRRx+ppKREGRkZmjp1qmbPnq1GjRpZa9uAAQO0bt06zZs3TytXrtSSJUvUsmVL/e53v9Ps2bN12WWXVWl/SUlJev/99/W73/1OGzZsUG5urkpKSlRcXFxpwIqKitIHH3ygv//973r22Wf16aefqrCwUGlpaZo5c6buu+8+a9+/uvvuu5WRkaE1a9Zo48aNOnr0qOLj49W+fXtNmDBBkydPVv369a08FwDgRw5jjAl0IwAAAAAgHPAdLAAAAACwhIAFAAAAAJYQsAAAAADAEgIWAAAAAFhCwAIAAAAASwhYAAAAAGAJAQsAAAAALCFgAQAAAIAlBCwAAAAAsISABQAAAACWELAAAAAAwBICFgAAAABYQsACAAAAAEv+P/hcqbEPPAquAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1000x1000 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt \n",
+    "\n",
+    "plt.figure(figsize=(10,10))\n",
+    "plt.imshow(design_all,interpolation='none')\n",
+    "plt.title('example design matrix from run 1',fontsize=16)\n",
+    "plt.xlabel('conditions',fontsize=16)\n",
+    "plt.ylabel('time (TR)',fontsize=16);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Okay, so I need to artificially split the runs and have 12 to see what's going on with these repeats. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(236, 300)\n",
+      "(163842, 236)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(design_list[0].shape)\n",
+    "print(data_list[0].shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One problem with this design is that repeated images are shown in the same run and no image is presented to the subject multiple times across multiple runs. This isn't the format that GLMSingle expects, but authors of the library have said it's okay to split the runs in half and create 12 runs using halves of the original runs and create pseudo-runs where it does look like repeats happen in different runs. This is necessary to get GLMSingle to work. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "split_val = 118\n",
+    "\n",
+    "design_list2 = [design_list[0][:split_val,:], design_list[0][split_val:,:], design_list[1][:split_val,:],\n",
+    "                design_list[1][split_val:,:], design_list[2][:split_val,:], design_list[2][split_val:,:],\n",
+    "                design_list[3][:split_val,:], design_list[3][split_val:,:], design_list[4][:split_val,:],\n",
+    "                design_list[4][split_val:,:], design_list[5][:split_val,:], design_list[5][split_val:,:]]\n",
+    "\n",
+    "data_list2 = [data_list[0][:,:split_val], data_list[0][:,split_val:], data_list[1][:,:split_val],\n",
+    "                data_list[1][:,split_val:], data_list[2][:,:split_val], data_list[2][:,split_val:],\n",
+    "                data_list[3][:,:split_val], data_list[3][:,split_val:], data_list[4][:,:split_val],\n",
+    "                data_list[4][:,split_val:], data_list[5][:,:split_val], data_list[5][:,split_val:]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'wantlibrary': 1, 'wantglmdenoise': 1, 'wantfracridge': 1, 'wantfileoutputs': [1, 1, 1, 1], 'wantmemoryoutputs': [1, 1, 1, 1], 'numforhrf': 50, 'hrfthresh': 0.5, 'hrffitmask': 1, 'R2thresh': 0, 'hrfmodel': 'optimise', 'n_jobs': 1, 'n_pcs': 10, 'n_boots': 100, 'extra_regressors': False, 'chunklen': 50000, 'wanthdf5': 0, 'wantparametric': 0, 'wantpercentbold': 1, 'wantlss': 0, 'brainthresh': [99.0, 0.1], 'brainR2': [], 'brainexclude': False, 'pcR2cutoff': [], 'pcR2cutoffmask': 1, 'pcstop': 1.05, 'fracs': array([1.  , 0.95, 0.9 , 0.85, 0.8 , 0.75, 0.7 , 0.65, 0.6 , 0.55, 0.5 ,\n",
+      "       0.45, 0.4 , 0.35, 0.3 , 0.25, 0.2 , 0.15, 0.1 , 0.05]), 'wantautoscale': 1, 'seed': 1732619319.067295, 'suppressoutput': 0, 'lambda': 0}\n",
+      "*** DIAGNOSTICS ***:\n",
+      "There are 12 runs.\n",
+      "The number of conditions in this experiment is 300.\n",
+      "The stimulus duration corresponding to each trial is 2.00 seconds.\n",
+      "The TR (time between successive data points) is 1.97 seconds.\n",
+      "The number of trials in each run is: [38, 37, 38, 37, 38, 37, 38, 37, 38, 37, 38, 37].\n",
+      "The number of trials for each condition is: [np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0)].\n",
+      "For each condition, the number of runs in which it appears: [np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(2), np.int64(1), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(2), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(1), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(1), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(1), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(2), np.int64(1), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(1), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(2), np.int64(1), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(1), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0)].\n",
+      "For each run, how much ending buffer do we have in seconds? [np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76)].\n",
+      "*** Saving design-related results to ./output/DESIGNINFO.npy. ***\n",
+      "*** FITTING DIAGNOSTIC RUN-WISE FIR MODEL ***\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alxmrphi/miniforge3/envs/glmsingle_demo/lib/python3.10/site-packages/glmsingle/glmsingle.py:659: UserWarning: Warning: You have specified trial onsets that occur less than 8 seconds from the end of at least one of the runs. This may cause estimation problems! As a solution, consider simply omitting specification of these ending trials from the original design matrix.\n",
+      "  warnings.warn(msg)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*** Saving FIR results to ./output/RUNWISEFIR.npy. ***\n",
+      "\n",
+      "*** FITTING TYPE-A MODEL (ONOFF) ***\n",
+      "\n",
+      "fitting model...\n",
+      "done.\n",
+      "\n",
+      "preparing output...\n",
+      "done.\n",
+      "\n",
+      "computing model fits...\n",
+      "done.\n",
+      "\n",
+      "computing R^2...\n",
+      "done.\n",
+      "\n",
+      "computing SNR...\n",
+      "done.\n",
+      "\n",
+      "\n",
+      "*** Saving results to ./output/TYPEA_ONOFF.npy. ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alxmrphi/miniforge3/envs/glmsingle_demo/lib/python3.10/site-packages/sklearn/mixture/_base.py:270: ConvergenceWarning: Best performing initialization did not converge. Try different init parameters, or increase max_iter, tol, or check for degenerate data.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*** Setting brain R2 threshold to 0.3795866394939522 ***\n",
+      "\n",
+      "*** FITTING TYPE-B MODEL (FITHRF) ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:   0%|          | 0/4 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  25%|██▌       | 1/4 [00:29<01:28, 29.38s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  50%|█████     | 2/4 [00:58<00:58, 29.05s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  75%|███████▌  | 3/4 [01:25<00:28, 28.38s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [01:54<00:00, 28.60s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** Saving results to ./output/TYPEB_FITHRF.npy. ***\n",
+      "\n",
+      "*** DETERMINING GLMDENOISE REGRESSORS ***\n",
+      "\n",
+      "*** CROSS-VALIDATING DIFFERENT NUMBERS OF REGRESSORS ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:   0%|          | 0/4 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  25%|██▌       | 1/4 [00:28<01:26, 28.92s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  50%|█████     | 2/4 [00:58<00:58, 29.19s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  75%|███████▌  | 3/4 [01:27<00:29, 29.05s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [01:56<00:00, 29.14s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** FITTING TYPE-C MODEL (GLMDENOISE) ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [00:16<00:00,  4.24s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** Saving results to ./output/TYPEC_FITHRF_GLMDENOISE.npy. ***\n",
+      "\n",
+      "*** FITTING TYPE-D MODEL (GLMDENOISE_RR) ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [04:11<00:00, 62.97s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** Saving results to ./output/TYPED_FITHRF_GLMDENOISE_RR.npy. ***\n",
+      "\n",
+      "*** All model types done ***\n",
+      "\n",
+      "*** return model types in results ***\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "opt = dict()\n",
+    "\n",
+    "# set important fields for completeness (but these would be enabled by default)\n",
+    "opt['wantlibrary'] = 1\n",
+    "opt['wantglmdenoise'] = 1\n",
+    "opt['wantfracridge'] = 1\n",
+    "\n",
+    "# for the purpose of this example we will keep the relevant outputs in memory\n",
+    "# and also save them to the disk\n",
+    "opt['wantfileoutputs'] = [1,1,1,1]\n",
+    "opt['wantmemoryoutputs'] = [1,1,1,1]\n",
+    "\n",
+    "# running python GLMsingle involves creating a GLM_single object\n",
+    "# and then running the procedure using the .fit() routine\n",
+    "glmsingle_obj = GLM_single(opt)\n",
+    "\n",
+    "# visualize all the hyperparameters\n",
+    "print(glmsingle_obj.params)\n",
+    "\n",
+    "tr = 1.97\n",
+    "stimdur = 2.0\n",
+    "\n",
+    "results_glmsingle = glmsingle_obj.fit(\n",
+    "    design_list2,\n",
+    "    data_list2,\n",
+    "    stimdur,\n",
+    "    tr,\n",
+    "    outputdir='./output')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*** DIAGNOSTICS ***:\n",
+    "There are 12 runs.\n",
+    "The number of conditions in this experiment is 300.\n",
+    "The stimulus duration corresponding to each trial is 2.00 seconds.\n",
+    "The TR (time between successive data points) is 1.97 seconds.\n",
+    "The number of trials in each run is: [38, 37, 38, 37, 38, 37, 38, 37, 38, 37, 38, 37].\n",
+    "The number of trials for each condition is: [np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0)]\n",
+    "\n",
+    "\n",
+    "What this is telling me is that condition 5 (from zero-indexing) isn't presented to this subject. But that can't be correct, right? "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Baird_Sparrow_5'"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "idx_to_fname[5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.0\n",
+      "0.0\n",
+      "0.0\n",
+      "0.0\n",
+      "0.0\n",
+      "0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(sum(design_list2[0][:,5]))\n",
+    "print(sum(design_list2[1][:,5]))\n",
+    "print(sum(design_list2[2][:,5]))\n",
+    "print(sum(design_list2[3][:,5]))\n",
+    "print(sum(design_list2[4][:,5]))\n",
+    "print(sum(design_list2[5][:,5]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It's true from looking at the .csv files that \"Baird_Sparrow_5\" is never shown to subject 35."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The returned object contains many useful calculations that could come in handy later, so let's save this object now."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 148,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sub_no = 35 \n",
+    "pickle.dump(results_glmsingle, open(f'sub_{sub_no}_glmsingle_results.pkl', 'wb'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "4 levels of results are calculated giving rise to `type[a-d]`, the last of which is the one we want."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['HRFindex', 'HRFindexrun', 'glmbadness', 'pcvoxels', 'pcnum', 'xvaltrend', 'noisepool', 'pcregressors', 'betasmd', 'R2', 'R2run', 'rrbadness', 'FRACvalue', 'scaleoffset', 'meanvol'])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results_glmsingle['typed'].keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The results returned from the fitting process for each \"type\" contain multiple sub-results. The two main ones are R2 (r-squared) and the actual beta values to use. We can use R^2 to verify that the voxels make the most sense (look like they belong to visual cortex). But first, let's see how many images the subject saw by summing up all the values in all of the design matrices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "np.float32(450.0)"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sum([sum(sum(x)) for x in design_list2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "450 images were seen. This means we expect per-vertex responses for 450 images. We can access them with this and see the shape here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(163842, 1, 1, 450)"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results_glmsingle['typed']['betasmd'].shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TODO \n",
+    "\n",
+    "I have not implemented any code to do the averaging just yet, but you should be able to make it work from this code:\n",
+    "\n",
+    "https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/examples/example1.html \n",
+    "\n",
+    "Specifically, go to the section called \"Get indices of repeated conditions to use for reliability calculations\" and copy the same idea given there. Check with me if any of this is unclear as this needs to be definitely correct, just needs someone to convert that code to our situation and then use that to average the values. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Beyond that, we can look at the R^2 reliability among muliple image presentations and look to see where the main bulk of activity is coming from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nilearn\n",
+    "import nilearn.datasets as datasets\n",
+    "import nilearn.experimental \n",
+    "from nilearn import datasets\n",
+    "import nilearn.experimental.surface\n",
+    "from nilearn import plotting\n",
+    "\n",
+    "fsaverage = datasets.fetch_surf_fsaverage(mesh='fsaverage')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(163842, 1, 1)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results_glmsingle['typed']['R2'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "67.82618 2.8210113\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(163842,)"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r2 = np.squeeze(results_glmsingle['typed']['R2'])\n",
+    "r2 = np.clip(r2, a_min=0, a_max=85)\n",
+    "print(max(r2), min(r2))\n",
+    "r2.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 194,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#view = plotting.view_surf(fsaverage.infl_left, r2, symmetric_cmap=True)\n",
+    "#view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looking at these values for the left surface, you can see the highest predictive accuracy (r^2) is indeed in the visual cortex and along the early ventral visual pathway."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It doesn't make as much sense to visualise the GLM values averaged together as much as it does to look at r^2 but we can still do it. I did expect the majority of acrtivity to be around the back of the brain (like the r^2) values but it seemed some results are also strong outside the main areas of interest. Note that the authors say this is expected to happen and since we restrict our areas of interest to ones in the Glasser atlas, we won't be looking across the whole brain (but we can do out of curiosity to see if more information might exist). I believe you have implemented a full-brain analysis already."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(163842,)"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "betasd = np.nanmean(np.squeeze(results_glmsingle['typed']['betasmd']), axis=1)\n",
+    "betasd = np.clip(betasd, a_min=-5, a_max=5)\n",
+    "betasd.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#view = plotting.view_surf(fsaverage.infl_left, betasd, symmetric_cmap=True)\n",
+    "#view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Averaging\n",
+    "\n",
+    "Some trials were presented multiple times. We will identify them and average the GLMSingle beta weights together for a strengthened response. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[203 292 294 171 294  51 201 203 290]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# consolidate design matrices\n",
+    "designALL = np.concatenate(design_list2,axis=0)\n",
+    "\n",
+    "# construct a vector containing 0-indexed condition numbers in chronological order\n",
+    "corder = []\n",
+    "for p in range(designALL.shape[0]):\n",
+    "    if np.any(designALL[p]):\n",
+    "        corder.append(np.argwhere(designALL[p])[0,0])\n",
+    "        \n",
+    "corder = np.array(corder)\n",
+    "print(corder[:9])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This should be that the first three trials of the experiment involved conditions 203, 292 and 294. We can check this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(np.int64(203), np.int64(292), np.int64(294))"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.argmax(design_list2[0][5]), np.argmax(design_list2[0][8]), np.argmax(design_list2[0][11])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "repindices = [] # 2 x images containing stimulus trial indices.\n",
+    "\n",
+    "# the first row refers to the first presentation; the second row refers to\n",
+    "# the second presentation.\n",
+    "for p in range(designALL.shape[1]): # loop over every condition\n",
+    "    \n",
+    "    temp = np.argwhere(corder==p)[:,0] # find indices where this condition was shown\n",
+    "    \n",
+    "    # note that for conditions with 3 presentations, we are simply ignoring the third trial\n",
+    "    assert len(temp) <= 3, \"More than 3 presentations of a stimulus\"\n",
+    "    if len(temp) >= 3:\n",
+    "        repindices.append([temp[0], temp[1], temp[2]])\n",
+    "    elif len(temp) == 2:\n",
+    "        print(\"Does this occur?\")\n",
+    "        repindices.append([temp[0], temp[1]])\n",
+    "\n",
+    "repindices = np.vstack(np.array(repindices)).T   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[233 238 237 227 226 277 231 245 225 273  21  33  14   9  10]\n",
+      " [244 247 270 229 251 286 281 261 232 275  28  39  41  32  16]\n",
+      " [279 295 280 296 269 289 293 271 262 288  60  59  67  51  27]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# let's take a look at a few entries\n",
+    "print(repindices[:,:15])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So the first condition (first bird image in the mapping) is presented at times `233`, `244` and `279`. The 5th condition (a different bird image) was presented at times `226`, `251` and `269`. Let's verify this by looking at the dataframe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('Savannah_Sparrow_3', 'Song_Sparrow_4', 'Vesper_Sparrow_9')"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "idx_to_fname[233], idx_to_fname[244], idx_to_fname[279]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(450, 163842)\n",
+      "trial = 3, n_reps = 150\n",
+      "tmp_reps = array([233, 244, 279])\n",
+      "x.shape = (3, 300)\n",
+      "np.argmax(x[j,:]) = np.int64(0)\n",
+      "np.argmax(x[j,:]) = np.int64(61)\n",
+      "np.argmax(x[j,:]) = np.int64(0)\n",
+      "tmp_reps = array([238, 247, 295])\n",
+      "x.shape = (3, 300)\n",
+      "np.argmax(x[j,:]) = np.int64(0)\n",
+      "np.argmax(x[j,:]) = np.int64(63)\n",
+      "np.argmax(x[j,:]) = np.int64(113)\n",
+      "tmp_reps = array([237, 270, 280])\n",
+      "x.shape = (3, 300)\n",
+      "np.argmax(x[j,:]) = np.int64(0)\n",
+      "np.argmax(x[j,:]) = np.int64(0)\n",
+      "np.argmax(x[j,:]) = np.int64(60)\n",
+      "tmp_reps = array([227, 229, 296])\n",
+      "x.shape = (3, 300)\n",
+      "np.argmax(x[j,:]) = np.int64(50)\n",
+      "np.argmax(x[j,:]) = np.int64(0)\n",
+      "np.argmax(x[j,:]) = np.int64(0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "betas = np.squeeze(results_glmsingle['typed']['betasmd']).T\n",
+    "print(betas.shape)\n",
+    "\n",
+    "trial, n_reps = np.array(repindices).shape\n",
+    "print(f\"trial = {trial}, n_reps = {n_reps}\")\n",
+    "\n",
+    "for i in range(4):\n",
+    "    tmp_reps = repindices[:,i]\n",
+    "    print(f\"{tmp_reps = }\")\n",
+    "    #print(betas[tmp_reps,:].shape)\n",
+    "    x = designALL[tmp_reps,:]\n",
+    "    print(f\"{x.shape = }\")\n",
+    "    for j in range(3):\n",
+    "        print(f\"{np.argmax(x[j,:]) = }\")\n",
+    "    \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "203"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fname_to_idx['Palm_Warbler_3']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "IndexError",
+     "evalue": "index 203 is out of bounds for axis 1 with size 150",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[63], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mrepindices\u001b[49m\u001b[43m[\u001b[49m\u001b[43m:\u001b[49m\u001b[43m,\u001b[49m\u001b[38;5;241;43m203\u001b[39;49m\u001b[43m]\u001b[49m\n",
+      "\u001b[0;31mIndexError\u001b[0m: index 203 is out of bounds for axis 1 with size 150"
+     ]
+    }
+   ],
+   "source": [
+    "repindices[:,203]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/3280883056.py:8: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['filename'] = events_df['stimulus'].apply(process_stim_column)\n",
+      "/var/folders/bw/t0cxr5650zs76qhy_qzhs6dm0000gn/T/ipykernel_12847/3280883056.py:9: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>onset</th>\n",
+       "      <th>duration</th>\n",
+       "      <th>tr</th>\n",
+       "      <th>stimulus</th>\n",
+       "      <th>class_id</th>\n",
+       "      <th>class_name</th>\n",
+       "      <th>image_number</th>\n",
+       "      <th>same</th>\n",
+       "      <th>response</th>\n",
+       "      <th>response_time_ms</th>\n",
+       "      <th>filename</th>\n",
+       "      <th>file_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>10.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>docs\\cropped\\174.Palm_Warbler_3.png</td>\n",
+       "      <td>174.0</td>\n",
+       "      <td>Palm_Warbler</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Palm_Warbler_3</td>\n",
+       "      <td>203</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>16.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_2.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_2</td>\n",
+       "      <td>292</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>22.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>11.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_4.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>3402.803225</td>\n",
+       "      <td>Yellow_Warbler_4</td>\n",
+       "      <td>294</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>28.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>14.0</td>\n",
+       "      <td>docs\\cropped\\172.Nashville_Warbler_1.png</td>\n",
+       "      <td>172.0</td>\n",
+       "      <td>Nashville_Warbler</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Nashville_Warbler_1</td>\n",
+       "      <td>171</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>34.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>17.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_4.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_4</td>\n",
+       "      <td>294</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>40.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>20.0</td>\n",
+       "      <td>docs\\cropped\\116.Chipping_Sparrow_1.png</td>\n",
+       "      <td>116.0</td>\n",
+       "      <td>Chipping_Sparrow</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Chipping_Sparrow_1</td>\n",
+       "      <td>51</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>46.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>23.0</td>\n",
+       "      <td>docs\\cropped\\174.Palm_Warbler_1.png</td>\n",
+       "      <td>174.0</td>\n",
+       "      <td>Palm_Warbler</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Palm_Warbler_1</td>\n",
+       "      <td>201</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>52.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>26.0</td>\n",
+       "      <td>docs\\cropped\\174.Palm_Warbler_3.png</td>\n",
+       "      <td>174.0</td>\n",
+       "      <td>Palm_Warbler</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>1476.713773</td>\n",
+       "      <td>Palm_Warbler_3</td>\n",
+       "      <td>203</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>58.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_0.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_0</td>\n",
+       "      <td>290</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>64.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>32.0</td>\n",
+       "      <td>docs\\cropped\\115.Brewer_Sparrow_3.png</td>\n",
+       "      <td>115.0</td>\n",
+       "      <td>Brewer_Sparrow</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Brewer_Sparrow_3</td>\n",
+       "      <td>23</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
+       "      <td>70.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>35.0</td>\n",
+       "      <td>docs\\cropped\\115.Brewer_Sparrow_4.png</td>\n",
+       "      <td>115.0</td>\n",
+       "      <td>Brewer_Sparrow</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>4701.610117</td>\n",
+       "      <td>Brewer_Sparrow_4</td>\n",
+       "      <td>24</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>76.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>38.0</td>\n",
+       "      <td>docs\\cropped\\116.Chipping_Sparrow_2.png</td>\n",
+       "      <td>116.0</td>\n",
+       "      <td>Chipping_Sparrow</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>2642.562262</td>\n",
+       "      <td>Chipping_Sparrow_2</td>\n",
+       "      <td>52</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25</th>\n",
+       "      <td>82.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>41.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_3.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_3</td>\n",
+       "      <td>293</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>88.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>44.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_1.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_1</td>\n",
+       "      <td>291</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29</th>\n",
+       "      <td>94.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>47.0</td>\n",
+       "      <td>docs\\cropped\\115.Brewer_Sparrow_2.png</td>\n",
+       "      <td>115.0</td>\n",
+       "      <td>Brewer_Sparrow</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Brewer_Sparrow_2</td>\n",
+       "      <td>22</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>31</th>\n",
+       "      <td>100.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>50.0</td>\n",
+       "      <td>docs\\cropped\\116.Chipping_Sparrow_1.png</td>\n",
+       "      <td>116.0</td>\n",
+       "      <td>Chipping_Sparrow</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Chipping_Sparrow_1</td>\n",
+       "      <td>51</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>33</th>\n",
+       "      <td>106.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>53.0</td>\n",
+       "      <td>docs\\cropped\\115.Brewer_Sparrow_4.png</td>\n",
+       "      <td>115.0</td>\n",
+       "      <td>Brewer_Sparrow</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Brewer_Sparrow_4</td>\n",
+       "      <td>24</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>35</th>\n",
+       "      <td>112.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>56.0</td>\n",
+       "      <td>docs\\cropped\\116.Chipping_Sparrow_2.png</td>\n",
+       "      <td>116.0</td>\n",
+       "      <td>Chipping_Sparrow</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Chipping_Sparrow_2</td>\n",
+       "      <td>52</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>37</th>\n",
+       "      <td>118.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>59.0</td>\n",
+       "      <td>docs\\cropped\\116.Chipping_Sparrow_4.png</td>\n",
+       "      <td>116.0</td>\n",
+       "      <td>Chipping_Sparrow</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Chipping_Sparrow_4</td>\n",
+       "      <td>54</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>39</th>\n",
+       "      <td>124.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>62.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_0.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_0</td>\n",
+       "      <td>290</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>41</th>\n",
+       "      <td>130.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>65.0</td>\n",
+       "      <td>docs\\cropped\\174.Palm_Warbler_4.png</td>\n",
+       "      <td>174.0</td>\n",
+       "      <td>Palm_Warbler</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Palm_Warbler_4</td>\n",
+       "      <td>204</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>43</th>\n",
+       "      <td>136.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>68.0</td>\n",
+       "      <td>docs\\cropped\\115.Brewer_Sparrow_0.png</td>\n",
+       "      <td>115.0</td>\n",
+       "      <td>Brewer_Sparrow</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Brewer_Sparrow_0</td>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>45</th>\n",
+       "      <td>142.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>71.0</td>\n",
+       "      <td>docs\\cropped\\182.Yellow_Warbler_1.png</td>\n",
+       "      <td>182.0</td>\n",
+       "      <td>Yellow_Warbler</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Yellow_Warbler_1</td>\n",
+       "      <td>291</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>47</th>\n",
+       "      <td>148.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>74.0</td>\n",
+       "      <td>docs\\cropped\\172.Nashville_Warbler_3.png</td>\n",
+       "      <td>172.0</td>\n",
+       "      <td>Nashville_Warbler</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Nashville_Warbler_3</td>\n",
+       "      <td>173</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>49</th>\n",
+       "      <td>154.0</td>\n",
+       "      <td>5.5</td>\n",
+       "      <td>77.0</td>\n",
+       "      <td>docs\\cropped\\172.Nashville_Warbler_1.png</td>\n",
+       "      <td>172.0</td>\n",
+       "      <td>Nashville_Warbler</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>2784.321631</td>\n",
+       "      <td>Nashville_Warbler_1</td>\n",
+       "      <td>171</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    onset  duration    tr                                  stimulus  class_id  \\\n",
+       "1    10.0       5.5   5.0       docs\\cropped\\174.Palm_Warbler_3.png     174.0   \n",
+       "3    16.0       5.5   8.0     docs\\cropped\\182.Yellow_Warbler_2.png     182.0   \n",
+       "5    22.0       5.5  11.0     docs\\cropped\\182.Yellow_Warbler_4.png     182.0   \n",
+       "7    28.0       5.5  14.0  docs\\cropped\\172.Nashville_Warbler_1.png     172.0   \n",
+       "9    34.0       5.5  17.0     docs\\cropped\\182.Yellow_Warbler_4.png     182.0   \n",
+       "11   40.0       5.5  20.0   docs\\cropped\\116.Chipping_Sparrow_1.png     116.0   \n",
+       "13   46.0       5.5  23.0       docs\\cropped\\174.Palm_Warbler_1.png     174.0   \n",
+       "15   52.0       5.5  26.0       docs\\cropped\\174.Palm_Warbler_3.png     174.0   \n",
+       "17   58.0       5.5  29.0     docs\\cropped\\182.Yellow_Warbler_0.png     182.0   \n",
+       "19   64.0       5.5  32.0     docs\\cropped\\115.Brewer_Sparrow_3.png     115.0   \n",
+       "21   70.0       5.5  35.0     docs\\cropped\\115.Brewer_Sparrow_4.png     115.0   \n",
+       "23   76.0       5.5  38.0   docs\\cropped\\116.Chipping_Sparrow_2.png     116.0   \n",
+       "25   82.0       5.5  41.0     docs\\cropped\\182.Yellow_Warbler_3.png     182.0   \n",
+       "27   88.0       5.5  44.0     docs\\cropped\\182.Yellow_Warbler_1.png     182.0   \n",
+       "29   94.0       5.5  47.0     docs\\cropped\\115.Brewer_Sparrow_2.png     115.0   \n",
+       "31  100.0       5.5  50.0   docs\\cropped\\116.Chipping_Sparrow_1.png     116.0   \n",
+       "33  106.0       5.5  53.0     docs\\cropped\\115.Brewer_Sparrow_4.png     115.0   \n",
+       "35  112.0       5.5  56.0   docs\\cropped\\116.Chipping_Sparrow_2.png     116.0   \n",
+       "37  118.0       5.5  59.0   docs\\cropped\\116.Chipping_Sparrow_4.png     116.0   \n",
+       "39  124.0       5.5  62.0     docs\\cropped\\182.Yellow_Warbler_0.png     182.0   \n",
+       "41  130.0       5.5  65.0       docs\\cropped\\174.Palm_Warbler_4.png     174.0   \n",
+       "43  136.0       5.5  68.0     docs\\cropped\\115.Brewer_Sparrow_0.png     115.0   \n",
+       "45  142.0       5.5  71.0     docs\\cropped\\182.Yellow_Warbler_1.png     182.0   \n",
+       "47  148.0       5.5  74.0  docs\\cropped\\172.Nashville_Warbler_3.png     172.0   \n",
+       "49  154.0       5.5  77.0  docs\\cropped\\172.Nashville_Warbler_1.png     172.0   \n",
+       "\n",
+       "           class_name  image_number   same  response  response_time_ms  \\\n",
+       "1        Palm_Warbler           3.0  False       NaN               NaN   \n",
+       "3      Yellow_Warbler           2.0  False       NaN               NaN   \n",
+       "5      Yellow_Warbler           4.0   True       3.0       3402.803225   \n",
+       "7   Nashville_Warbler           1.0  False       NaN               NaN   \n",
+       "9      Yellow_Warbler           4.0  False       NaN               NaN   \n",
+       "11   Chipping_Sparrow           1.0  False       NaN               NaN   \n",
+       "13       Palm_Warbler           1.0  False       NaN               NaN   \n",
+       "15       Palm_Warbler           3.0   True       3.0       1476.713773   \n",
+       "17     Yellow_Warbler           0.0  False       NaN               NaN   \n",
+       "19     Brewer_Sparrow           3.0  False       NaN               NaN   \n",
+       "21     Brewer_Sparrow           4.0   True       3.0       4701.610117   \n",
+       "23   Chipping_Sparrow           2.0  False       3.0       2642.562262   \n",
+       "25     Yellow_Warbler           3.0  False       NaN               NaN   \n",
+       "27     Yellow_Warbler           1.0   True       NaN               NaN   \n",
+       "29     Brewer_Sparrow           2.0  False       NaN               NaN   \n",
+       "31   Chipping_Sparrow           1.0  False       NaN               NaN   \n",
+       "33     Brewer_Sparrow           4.0  False       NaN               NaN   \n",
+       "35   Chipping_Sparrow           2.0  False       NaN               NaN   \n",
+       "37   Chipping_Sparrow           4.0   True       NaN               NaN   \n",
+       "39     Yellow_Warbler           0.0  False       NaN               NaN   \n",
+       "41       Palm_Warbler           4.0  False       NaN               NaN   \n",
+       "43     Brewer_Sparrow           0.0  False       NaN               NaN   \n",
+       "45     Yellow_Warbler           1.0  False       NaN               NaN   \n",
+       "47  Nashville_Warbler           3.0  False       NaN               NaN   \n",
+       "49  Nashville_Warbler           1.0   True       3.0       2784.321631   \n",
+       "\n",
+       "               filename  file_id  \n",
+       "1        Palm_Warbler_3      203  \n",
+       "3      Yellow_Warbler_2      292  \n",
+       "5      Yellow_Warbler_4      294  \n",
+       "7   Nashville_Warbler_1      171  \n",
+       "9      Yellow_Warbler_4      294  \n",
+       "11   Chipping_Sparrow_1       51  \n",
+       "13       Palm_Warbler_1      201  \n",
+       "15       Palm_Warbler_3      203  \n",
+       "17     Yellow_Warbler_0      290  \n",
+       "19     Brewer_Sparrow_3       23  \n",
+       "21     Brewer_Sparrow_4       24  \n",
+       "23   Chipping_Sparrow_2       52  \n",
+       "25     Yellow_Warbler_3      293  \n",
+       "27     Yellow_Warbler_1      291  \n",
+       "29     Brewer_Sparrow_2       22  \n",
+       "31   Chipping_Sparrow_1       51  \n",
+       "33     Brewer_Sparrow_4       24  \n",
+       "35   Chipping_Sparrow_2       52  \n",
+       "37   Chipping_Sparrow_4       54  \n",
+       "39     Yellow_Warbler_0      290  \n",
+       "41       Palm_Warbler_4      204  \n",
+       "43     Brewer_Sparrow_0       20  \n",
+       "45     Yellow_Warbler_1      291  \n",
+       "47  Nashville_Warbler_3      173  \n",
+       "49  Nashville_Warbler_1      171  "
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "run_no = 1\n",
+    "func_file = Path(f'sub-{sub_no}_task-bird_run-{run_no}_hemi-L_space-fsaverage_bold.func.gii')\n",
+    "data = surf.load_surf_data(func_folder / func_file)\n",
+    "file = Path(f'TC2See_35_{run_no}_result_store.csv')\n",
+    "path = folder / file\n",
+    "df = pd.read_csv(path, sep='\\t')\n",
+    "events_df = df[df['stimulus'].str.endswith('png')] \n",
+    "events_df['filename'] = events_df['stimulus'].apply(process_stim_column)\n",
+    "events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)\n",
+    "events_df.head(25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "there are 150 repeated conditions in the experiment\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'there are {repindices.shape[1]} repeated conditions in the experiment')\n",
+    "\n",
+    "# now, for each voxel we are going to correlate beta weights describing the\n",
+    "# response to images presented for the first time with beta weights\n",
+    "# describing the response from the repetition of the same image. with 136\n",
+    "# repeated conditions, the correlation for each voxel will reflect the\n",
+    "# relationship between two vectors with 136 beta weights each."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(163842, 1, 1, 450)"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results_glmsingle['typed']['betasmd'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(450, 163842)\n"
+     ]
+    }
+   ],
+   "source": [
+    "betas = np.squeeze(results_glmsingle['typed']['betasmd']).T\n",
+    "print(betas.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 113,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n_trs = 1416, n_conds = 300\n",
+      "[203 292 294 171 294  51 201 203 290]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# consolidate design matrices\n",
+    "designALL = np.concatenate(design_list2,axis=0)\n",
+    "n_trs, n_conds = designALL.shape\n",
+    "\n",
+    "print(f\"{n_trs = }, {n_conds = }\")\n",
+    "\n",
+    "# construct a vector containing 0-indexed condition numbers in chronological order\n",
+    "cond_order = []\n",
+    "for p in range(n_trs):\n",
+    "    # some TRs are acquired but have no stimulus presentation in them and are all zero, ignore these\n",
+    "    if np.any(designALL[p]):\n",
+    "        tmp = np.argwhere(designALL[p])[0,0]\n",
+    "        #print(tmp)\n",
+    "        cond_order.append(tmp)\n",
+    "        \n",
+    "cond_order = np.array(cond_order)\n",
+    "print(cond_order[:9])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(450, np.int64(3))"
+      ]
+     },
+     "execution_count": 117,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(cond_order), sum(cond_order==4)\n",
+    "# (450, np.int64(3))\n",
+    "# condition '4' was presented three times"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 114,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[226]\n",
+      " [251]\n",
+      " [269]]\n",
+      "[226 251 269]\n",
+      "Baird_Sparrow_4\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(np.argwhere(cond_order==4))\n",
+    "print(np.argwhere(cond_order==4)[:,0])\n",
+    "print(idx_to_fname[4]) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "des"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Condition 0. File = Baird_Sparrow_0, at TRs [233, 244, 279]\n",
+      "Condition 1. File = Baird_Sparrow_1, at TRs [238, 247, 295]\n",
+      "Condition 2. File = Baird_Sparrow_2, at TRs [237, 270, 280]\n",
+      "Condition 3. File = Baird_Sparrow_3, at TRs [227, 229, 296]\n",
+      "Condition 4. File = Baird_Sparrow_4, at TRs [226, 251, 269]\n",
+      "Condition 10. File = Blue_winged_Warbler_0, at TRs [277, 286, 289]\n",
+      "Condition 11. File = Blue_winged_Warbler_1, at TRs [231, 281, 293]\n",
+      "Condition 12. File = Blue_winged_Warbler_2, at TRs [245, 261, 271]\n",
+      "Condition 13. File = Blue_winged_Warbler_3, at TRs [225, 232, 262]\n",
+      "Condition 14. File = Blue_winged_Warbler_4, at TRs [273, 275, 288]\n",
+      "Condition 20. File = Brewer_Sparrow_0, at TRs [21, 28, 60]\n",
+      "Condition 21. File = Brewer_Sparrow_1, at TRs [33, 39, 59]\n",
+      "Condition 22. File = Brewer_Sparrow_2, at TRs [14, 41, 67]\n",
+      "Condition 23. File = Brewer_Sparrow_3, at TRs [9, 32, 51]\n",
+      "Condition 24. File = Brewer_Sparrow_4, at TRs [10, 16, 27]\n",
+      "Condition 30. File = Canada_Warbler_0, at TRs [105, 117, 132]\n",
+      "Condition 31. File = Canada_Warbler_1, at TRs [106, 141, 147]\n",
+      "Condition 32. File = Canada_Warbler_2, at TRs [78, 99, 109]\n",
+      "Condition 33. File = Canada_Warbler_3, at TRs [118, 128, 137]\n",
+      "Condition 34. File = Canada_Warbler_4, at TRs [98, 110, 148]\n",
+      "Condition 40. File = Cape_May_Warbler_0, at TRs [181, 216, 222]\n",
+      "Condition 41. File = Cape_May_Warbler_1, at TRs [180, 192, 207]\n",
+      "Condition 42. File = Cape_May_Warbler_2, at TRs [193, 203, 212]\n",
+      "Condition 43. File = Cape_May_Warbler_3, at TRs [153, 174, 184]\n",
+      "Condition 44. File = Cape_May_Warbler_4, at TRs [173, 185, 223]\n",
+      "Condition 50. File = Chipping_Sparrow_0, at TRs [47, 58, 74]\n",
+      "Condition 51. File = Chipping_Sparrow_1, at TRs [5, 15, 65]\n",
+      "Condition 52. File = Chipping_Sparrow_2, at TRs [11, 17, 25]\n",
+      "Condition 53. File = Chipping_Sparrow_3, at TRs [38, 49, 69]\n",
+      "Condition 54. File = Chipping_Sparrow_4, at TRs [18, 29, 40]\n",
+      "Condition 60. File = Clay_colored_Sparrow_0, at TRs [88, 97, 145]\n",
+      "Condition 61. File = Clay_colored_Sparrow_1, at TRs [76, 101, 119]\n",
+      "Condition 62. File = Clay_colored_Sparrow_2, at TRs [87, 120, 130]\n",
+      "Condition 63. File = Clay_colored_Sparrow_3, at TRs [77, 79, 146]\n",
+      "Condition 64. File = Clay_colored_Sparrow_4, at TRs [83, 94, 129]\n",
+      "Condition 70. File = Field_Sparrow_0, at TRs [310, 316, 327]\n",
+      "Condition 71. File = Field_Sparrow_1, at TRs [333, 339, 359]\n",
+      "Condition 72. File = Field_Sparrow_2, at TRs [309, 332, 351]\n",
+      "Condition 73. File = Field_Sparrow_3, at TRs [314, 341, 367]\n",
+      "Condition 74. File = Field_Sparrow_4, at TRs [321, 328, 360]\n",
+      "Condition 80. File = Grasshopper_Sparrow_0, at TRs [389, 416, 442]\n",
+      "Condition 81. File = Grasshopper_Sparrow_1, at TRs [385, 391, 402]\n",
+      "Condition 82. File = Grasshopper_Sparrow_2, at TRs [408, 414, 434]\n",
+      "Condition 83. File = Grasshopper_Sparrow_3, at TRs [396, 403, 435]\n",
+      "Condition 84. File = Grasshopper_Sparrow_4, at TRs [384, 407, 426]\n",
+      "Condition 90. File = Henslow_Sparrow_0, at TRs [387, 420, 430]\n",
+      "Condition 91. File = Henslow_Sparrow_1, at TRs [383, 394, 429]\n",
+      "Condition 92. File = Henslow_Sparrow_2, at TRs [377, 379, 446]\n",
+      "Condition 93. File = Henslow_Sparrow_3, at TRs [388, 397, 445]\n",
+      "Condition 94. File = Henslow_Sparrow_4, at TRs [376, 401, 419]\n",
+      "Condition 100. File = Hooded_Warbler_0, at TRs [323, 335, 373]\n",
+      "Condition 101. File = Hooded_Warbler_1, at TRs [303, 324, 334]\n",
+      "Condition 102. File = Hooded_Warbler_2, at TRs [330, 342, 357]\n",
+      "Condition 103. File = Hooded_Warbler_3, at TRs [343, 353, 362]\n",
+      "Condition 104. File = Hooded_Warbler_4, at TRs [331, 366, 372]\n",
+      "Condition 110. File = House_Sparrow_0, at TRs [122, 133, 149]\n",
+      "Condition 111. File = House_Sparrow_1, at TRs [86, 92, 100]\n",
+      "Condition 112. File = House_Sparrow_2, at TRs [80, 90, 140]\n",
+      "Condition 113. File = House_Sparrow_3, at TRs [93, 104, 115]\n",
+      "Condition 114. File = House_Sparrow_4, at TRs [113, 124, 144]\n",
+      "Condition 120. File = Kentucky_Warbler_0, at TRs [158, 169, 204]\n",
+      "Condition 121. File = Kentucky_Warbler_1, at TRs [163, 172, 220]\n",
+      "Condition 122. File = Kentucky_Warbler_2, at TRs [162, 195, 205]\n",
+      "Condition 123. File = Kentucky_Warbler_3, at TRs [151, 176, 194]\n",
+      "Condition 124. File = Kentucky_Warbler_4, at TRs [152, 154, 221]\n",
+      "Condition 130. File = Le_Conte_Sparrow_0, at TRs [159, 182, 201]\n",
+      "Condition 131. File = Le_Conte_Sparrow_1, at TRs [164, 191, 217]\n",
+      "Condition 132. File = Le_Conte_Sparrow_2, at TRs [160, 166, 177]\n",
+      "Condition 133. File = Le_Conte_Sparrow_3, at TRs [183, 189, 209]\n",
+      "Condition 134. File = Le_Conte_Sparrow_4, at TRs [171, 178, 210]\n",
+      "Condition 140. File = Lincoln_Sparrow_0, at TRs [188, 199, 219]\n",
+      "Condition 141. File = Lincoln_Sparrow_1, at TRs [168, 179, 190]\n",
+      "Condition 142. File = Lincoln_Sparrow_2, at TRs [197, 208, 224]\n",
+      "Condition 143. File = Lincoln_Sparrow_3, at TRs [155, 165, 215]\n",
+      "Condition 144. File = Lincoln_Sparrow_4, at TRs [161, 167, 175]\n",
+      "Condition 150. File = Magnolia_Warbler_0, at TRs [95, 111, 121]\n",
+      "Condition 151. File = Magnolia_Warbler_1, at TRs [75, 82, 112]\n",
+      "Condition 152. File = Magnolia_Warbler_2, at TRs [81, 131, 143]\n",
+      "Condition 153. File = Magnolia_Warbler_3, at TRs [123, 125, 138]\n",
+      "Condition 154. File = Magnolia_Warbler_4, at TRs [127, 136, 139]\n",
+      "Condition 160. File = Mourning_Warbler_0, at TRs [395, 411, 421]\n",
+      "Condition 161. File = Mourning_Warbler_1, at TRs [423, 425, 438]\n",
+      "Condition 162. File = Mourning_Warbler_2, at TRs [427, 436, 439]\n",
+      "Condition 163. File = Mourning_Warbler_3, at TRs [375, 382, 412]\n",
+      "Condition 164. File = Mourning_Warbler_4, at TRs [381, 431, 443]\n",
+      "Condition 170. File = Nashville_Warbler_0, at TRs [43, 53, 62]\n",
+      "Condition 171. File = Nashville_Warbler_1, at TRs [3, 24, 34]\n",
+      "Condition 172. File = Nashville_Warbler_2, at TRs [30, 42, 57]\n",
+      "Condition 173. File = Nashville_Warbler_3, at TRs [23, 35, 73]\n",
+      "Condition 174. File = Nashville_Warbler_4, at TRs [31, 66, 72]\n",
+      "Condition 180. File = Nelson_Sharp_tailed_Sparrow_0, at TRs [230, 240, 290]\n",
+      "Condition 181. File = Nelson_Sharp_tailed_Sparrow_1, at TRs [272, 283, 299]\n",
+      "Condition 182. File = Nelson_Sharp_tailed_Sparrow_2, at TRs [243, 254, 265]\n",
+      "Condition 183. File = Nelson_Sharp_tailed_Sparrow_3, at TRs [263, 274, 294]\n",
+      "Condition 184. File = Nelson_Sharp_tailed_Sparrow_4, at TRs [236, 242, 250]\n",
+      "Condition 190. File = Orange_crowned_Warbler_0, at TRs [150, 157, 187]\n",
+      "Condition 191. File = Orange_crowned_Warbler_1, at TRs [170, 186, 196]\n",
+      "Condition 192. File = Orange_crowned_Warbler_2, at TRs [198, 200, 213]\n",
+      "Condition 193. File = Orange_crowned_Warbler_3, at TRs [202, 211, 214]\n",
+      "Condition 194. File = Orange_crowned_Warbler_4, at TRs [156, 206, 218]\n",
+      "Condition 200. File = Palm_Warbler_0, at TRs [52, 61, 64]\n",
+      "Condition 201. File = Palm_Warbler_1, at TRs [6, 56, 68]\n",
+      "Condition 202. File = Palm_Warbler_2, at TRs [48, 50, 63]\n",
+      "Condition 203. File = Palm_Warbler_3, at TRs [0, 7, 37]\n",
+      "Condition 204. File = Palm_Warbler_4, at TRs [20, 36, 46]\n",
+      "Condition 210. File = Pine_Warbler_0, at TRs [352, 361, 364]\n",
+      "Condition 211. File = Pine_Warbler_1, at TRs [300, 307, 337]\n",
+      "Condition 212. File = Pine_Warbler_2, at TRs [306, 356, 368]\n",
+      "Condition 213. File = Pine_Warbler_3, at TRs [320, 336, 346]\n",
+      "Condition 214. File = Pine_Warbler_4, at TRs [348, 350, 363]\n",
+      "Condition 220. File = Prairie_Warbler_0, at TRs [398, 410, 448]\n",
+      "Condition 221. File = Prairie_Warbler_1, at TRs [405, 417, 432]\n",
+      "Condition 222. File = Prairie_Warbler_2, at TRs [378, 399, 409]\n",
+      "Condition 223. File = Prairie_Warbler_3, at TRs [418, 428, 437]\n",
+      "Condition 224. File = Prairie_Warbler_4, at TRs [406, 441, 447]\n",
+      "Condition 230. File = Savannah_Sparrow_0, at TRs [84, 107, 126]\n",
+      "Condition 231. File = Savannah_Sparrow_1, at TRs [96, 103, 135]\n",
+      "Condition 232. File = Savannah_Sparrow_2, at TRs [108, 114, 134]\n",
+      "Condition 233. File = Savannah_Sparrow_3, at TRs [89, 116, 142]\n",
+      "Condition 234. File = Savannah_Sparrow_4, at TRs [85, 91, 102]\n",
+      "Condition 240. File = Song_Sparrow_0, at TRs [393, 404, 415]\n",
+      "Condition 241. File = Song_Sparrow_1, at TRs [386, 392, 400]\n",
+      "Condition 242. File = Song_Sparrow_2, at TRs [422, 433, 449]\n",
+      "Condition 243. File = Song_Sparrow_3, at TRs [380, 390, 440]\n",
+      "Condition 244. File = Song_Sparrow_4, at TRs [413, 424, 444]\n",
+      "Condition 250. File = Tennessee_Warbler_0, at TRs [301, 326, 344]\n",
+      "Condition 251. File = Tennessee_Warbler_1, at TRs [312, 345, 355]\n",
+      "Condition 252. File = Tennessee_Warbler_2, at TRs [302, 304, 371]\n",
+      "Condition 253. File = Tennessee_Warbler_3, at TRs [308, 319, 354]\n",
+      "Condition 254. File = Tennessee_Warbler_4, at TRs [313, 322, 370]\n",
+      "Condition 260. File = Tree_Sparrow_0, at TRs [318, 329, 340]\n",
+      "Condition 261. File = Tree_Sparrow_1, at TRs [347, 358, 374]\n",
+      "Condition 262. File = Tree_Sparrow_2, at TRs [338, 349, 369]\n",
+      "Condition 263. File = Tree_Sparrow_3, at TRs [305, 315, 365]\n",
+      "Condition 264. File = Tree_Sparrow_4, at TRs [311, 317, 325]\n",
+      "Condition 270. File = Vesper_Sparrow_0, at TRs [246, 253, 285]\n",
+      "Condition 271. File = Vesper_Sparrow_1, at TRs [239, 266, 292]\n",
+      "Condition 272. File = Vesper_Sparrow_2, at TRs [234, 257, 276]\n",
+      "Condition 273. File = Vesper_Sparrow_3, at TRs [258, 264, 284]\n",
+      "Condition 274. File = Vesper_Sparrow_4, at TRs [235, 241, 252]\n",
+      "Condition 280. File = Wilson_Warbler_0, at TRs [228, 249, 259]\n",
+      "Condition 281. File = Wilson_Warbler_1, at TRs [255, 267, 282]\n",
+      "Condition 282. File = Wilson_Warbler_2, at TRs [256, 291, 297]\n",
+      "Condition 283. File = Wilson_Warbler_3, at TRs [248, 260, 298]\n",
+      "Condition 284. File = Wilson_Warbler_4, at TRs [268, 278, 287]\n",
+      "Condition 290. File = Yellow_Warbler_0, at TRs [8, 19, 54]\n",
+      "Condition 291. File = Yellow_Warbler_1, at TRs [13, 22, 70]\n",
+      "Condition 292. File = Yellow_Warbler_2, at TRs [1, 26, 44]\n",
+      "Condition 293. File = Yellow_Warbler_3, at TRs [12, 45, 55]\n",
+      "Condition 294. File = Yellow_Warbler_4, at TRs [2, 4, 71]\n",
+      "repTRs.shape = (150, 3)\n",
+      "repTRs.shape = (3, 150)\n",
+      "150\n"
+     ]
+    }
+   ],
+   "source": [
+    "repTRs = [] # 2 x images containing stimulus trial indices.\n",
+    "conds_seen = []\n",
+    "cond_trs = []\n",
+    "\n",
+    "# the first row refers to the first presentation; the second row refers to\n",
+    "# the second presentation.\n",
+    "for cond in range(n_conds): # loop over every condition\n",
+    "    \n",
+    "    TRs = np.argwhere(cond_order==cond)[:,0] # find TRs where this condition was shown\n",
+    "    \n",
+    "    # note that for conditions with 3 presentations, we are simply ignoring the third trial\n",
+    "    assert len(TRs) == 3, \"Investigate potential problem here. Number of presentatinos for this condition != 3\"\n",
+    "    if len(TRs) >= 3:\n",
+    "        selected_TRs = [int(TRs[0]), int(TRs[1]), int(TRs[2])]\n",
+    "        repTRs.append(selected_TRs)\n",
+    "        conds_seen.append(cond)\n",
+    "        cond_trs.append((cond, selected_TRs))\n",
+    "        print(f\"Condition {cond}. File = {idx_to_fname[cond]}, at TRs {selected_TRs}\")\n",
+    "\n",
+    "repTRs = np.array(repTRs)\n",
+    "print(f\"{repTRs.shape = }\")\n",
+    "repTRs = np.vstack(repTRs).T   \n",
+    "print(f\"{repTRs.shape = }\")\n",
+    "print(len(conds_seen))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now with `conds_seen` I can iterate through this list, get the filename, get the TRs, average beta responses and store them somewhere. It will be a NumPy array and it will have a new index over to 150 and inside, it will have the vertex information for that trial as well as what numbered condition (out of the 300 images) it belongs to. Then save this as a NumPy array. Actually maybe separate array for the mapping."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(0, [233, 244, 279]),\n",
+       " (1, [238, 247, 295]),\n",
+       " (2, [237, 270, 280]),\n",
+       " (3, [227, 229, 296]),\n",
+       " (4, [226, 251, 269]),\n",
+       " (10, [277, 286, 289]),\n",
+       " (11, [231, 281, 293]),\n",
+       " (12, [245, 261, 271]),\n",
+       " (13, [225, 232, 262]),\n",
+       " (14, [273, 275, 288]),\n",
+       " (20, [21, 28, 60]),\n",
+       " (21, [33, 39, 59]),\n",
+       " (22, [14, 41, 67]),\n",
+       " (23, [9, 32, 51]),\n",
+       " (24, [10, 16, 27]),\n",
+       " (30, [105, 117, 132]),\n",
+       " (31, [106, 141, 147]),\n",
+       " (32, [78, 99, 109]),\n",
+       " (33, [118, 128, 137]),\n",
+       " (34, [98, 110, 148]),\n",
+       " (40, [181, 216, 222]),\n",
+       " (41, [180, 192, 207]),\n",
+       " (42, [193, 203, 212]),\n",
+       " (43, [153, 174, 184]),\n",
+       " (44, [173, 185, 223]),\n",
+       " (50, [47, 58, 74]),\n",
+       " (51, [5, 15, 65]),\n",
+       " (52, [11, 17, 25]),\n",
+       " (53, [38, 49, 69]),\n",
+       " (54, [18, 29, 40]),\n",
+       " (60, [88, 97, 145]),\n",
+       " (61, [76, 101, 119]),\n",
+       " (62, [87, 120, 130]),\n",
+       " (63, [77, 79, 146]),\n",
+       " (64, [83, 94, 129]),\n",
+       " (70, [310, 316, 327]),\n",
+       " (71, [333, 339, 359]),\n",
+       " (72, [309, 332, 351]),\n",
+       " (73, [314, 341, 367]),\n",
+       " (74, [321, 328, 360]),\n",
+       " (80, [389, 416, 442]),\n",
+       " (81, [385, 391, 402]),\n",
+       " (82, [408, 414, 434]),\n",
+       " (83, [396, 403, 435]),\n",
+       " (84, [384, 407, 426]),\n",
+       " (90, [387, 420, 430]),\n",
+       " (91, [383, 394, 429]),\n",
+       " (92, [377, 379, 446]),\n",
+       " (93, [388, 397, 445]),\n",
+       " (94, [376, 401, 419]),\n",
+       " (100, [323, 335, 373]),\n",
+       " (101, [303, 324, 334]),\n",
+       " (102, [330, 342, 357]),\n",
+       " (103, [343, 353, 362]),\n",
+       " (104, [331, 366, 372]),\n",
+       " (110, [122, 133, 149]),\n",
+       " (111, [86, 92, 100]),\n",
+       " (112, [80, 90, 140]),\n",
+       " (113, [93, 104, 115]),\n",
+       " (114, [113, 124, 144]),\n",
+       " (120, [158, 169, 204]),\n",
+       " (121, [163, 172, 220]),\n",
+       " (122, [162, 195, 205]),\n",
+       " (123, [151, 176, 194]),\n",
+       " (124, [152, 154, 221]),\n",
+       " (130, [159, 182, 201]),\n",
+       " (131, [164, 191, 217]),\n",
+       " (132, [160, 166, 177]),\n",
+       " (133, [183, 189, 209]),\n",
+       " (134, [171, 178, 210]),\n",
+       " (140, [188, 199, 219]),\n",
+       " (141, [168, 179, 190]),\n",
+       " (142, [197, 208, 224]),\n",
+       " (143, [155, 165, 215]),\n",
+       " (144, [161, 167, 175]),\n",
+       " (150, [95, 111, 121]),\n",
+       " (151, [75, 82, 112]),\n",
+       " (152, [81, 131, 143]),\n",
+       " (153, [123, 125, 138]),\n",
+       " (154, [127, 136, 139]),\n",
+       " (160, [395, 411, 421]),\n",
+       " (161, [423, 425, 438]),\n",
+       " (162, [427, 436, 439]),\n",
+       " (163, [375, 382, 412]),\n",
+       " (164, [381, 431, 443]),\n",
+       " (170, [43, 53, 62]),\n",
+       " (171, [3, 24, 34]),\n",
+       " (172, [30, 42, 57]),\n",
+       " (173, [23, 35, 73]),\n",
+       " (174, [31, 66, 72]),\n",
+       " (180, [230, 240, 290]),\n",
+       " (181, [272, 283, 299]),\n",
+       " (182, [243, 254, 265]),\n",
+       " (183, [263, 274, 294]),\n",
+       " (184, [236, 242, 250]),\n",
+       " (190, [150, 157, 187]),\n",
+       " (191, [170, 186, 196]),\n",
+       " (192, [198, 200, 213]),\n",
+       " (193, [202, 211, 214]),\n",
+       " (194, [156, 206, 218]),\n",
+       " (200, [52, 61, 64]),\n",
+       " (201, [6, 56, 68]),\n",
+       " (202, [48, 50, 63]),\n",
+       " (203, [0, 7, 37]),\n",
+       " (204, [20, 36, 46]),\n",
+       " (210, [352, 361, 364]),\n",
+       " (211, [300, 307, 337]),\n",
+       " (212, [306, 356, 368]),\n",
+       " (213, [320, 336, 346]),\n",
+       " (214, [348, 350, 363]),\n",
+       " (220, [398, 410, 448]),\n",
+       " (221, [405, 417, 432]),\n",
+       " (222, [378, 399, 409]),\n",
+       " (223, [418, 428, 437]),\n",
+       " (224, [406, 441, 447]),\n",
+       " (230, [84, 107, 126]),\n",
+       " (231, [96, 103, 135]),\n",
+       " (232, [108, 114, 134]),\n",
+       " (233, [89, 116, 142]),\n",
+       " (234, [85, 91, 102]),\n",
+       " (240, [393, 404, 415]),\n",
+       " (241, [386, 392, 400]),\n",
+       " (242, [422, 433, 449]),\n",
+       " (243, [380, 390, 440]),\n",
+       " (244, [413, 424, 444]),\n",
+       " (250, [301, 326, 344]),\n",
+       " (251, [312, 345, 355]),\n",
+       " (252, [302, 304, 371]),\n",
+       " (253, [308, 319, 354]),\n",
+       " (254, [313, 322, 370]),\n",
+       " (260, [318, 329, 340]),\n",
+       " (261, [347, 358, 374]),\n",
+       " (262, [338, 349, 369]),\n",
+       " (263, [305, 315, 365]),\n",
+       " (264, [311, 317, 325]),\n",
+       " (270, [246, 253, 285]),\n",
+       " (271, [239, 266, 292]),\n",
+       " (272, [234, 257, 276]),\n",
+       " (273, [258, 264, 284]),\n",
+       " (274, [235, 241, 252]),\n",
+       " (280, [228, 249, 259]),\n",
+       " (281, [255, 267, 282]),\n",
+       " (282, [256, 291, 297]),\n",
+       " (283, [248, 260, 298]),\n",
+       " (284, [268, 278, 287]),\n",
+       " (290, [8, 19, 54]),\n",
+       " (291, [13, 22, 70]),\n",
+       " (292, [1, 26, 44]),\n",
+       " (293, [12, 45, 55]),\n",
+       " (294, [2, 4, 71])]"
+      ]
+     },
+     "execution_count": 147,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\n",
+    "pickle.dump(cond_trs, open(f'condition_tr_mapping_subject_{sub_no}.pkl', 'wb'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 145,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([False, False, False,  True, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False, False, False, False,\n",
+       "       False, False, False, False, False, False])"
+      ]
+     },
+     "execution_count": 145,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(np.array(conds_seen) == 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 151,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(450, 163842)"
+      ]
+     },
+     "execution_count": 151,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(repTRs[0])\n",
+    "betas.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Indexing Issue\n",
+    "\n",
+    "Not all subjects see all conditions, so above if we examine the first ten bird images (conditions) and look at their TRs in the concatenated list, we see:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 154,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[(0, [233, 244, 279]),\n",
+       " (1, [238, 247, 295]),\n",
+       " (2, [237, 270, 280]),\n",
+       " (3, [227, 229, 296]),\n",
+       " (4, [226, 251, 269]),\n",
+       " (10, [277, 286, 289]),\n",
+       " (11, [231, 281, 293]),\n",
+       " (12, [245, 261, 271]),\n",
+       " (13, [225, 232, 262]),\n",
+       " (14, [273, 275, 288])]"
+      ]
+     },
+     "execution_count": 154,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cond_trs[:10]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Conditions `5-9` were not shown to the subject, so when we do the averaging, which will naturally go from `0-149` then there could be a mismatch. So, we need to store the conditions list so we know what index refers to what. If we loaded the beta values for this subject and we wanted to access the averaged GLMSingle beta response to the image `Blue_winged_Warbler_0` then we first need to get its index value in the whole experiment ... "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 159,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10"
+      ]
+     },
+     "execution_count": 159,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fname_to_idx['Blue_winged_Warbler_0']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we look at the `cond_trs` information above, we can see that index 10 occurs at index `5` so we need to always make sure when referencing a specific condition, we look at the index where that is found in the `cond_trs` variable or the `conds_seen` varialbe (which store the same information)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 161,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(163842,)"
+      ]
+     },
+     "execution_count": 161,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "betas[10,:].shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build the Average Version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(450, 163842)"
+      ]
+     },
+     "execution_count": 163,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "betas.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 164,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_repeated_conds = len(repTRs[0])\n",
+    "n_vertices = betas.shape[1]\n",
+    "\n",
+    "betas_averaged = np.zeros((n_repeated_conds, n_vertices)) # i.e. (150, 163842) \n",
+    "\n",
+    "for i, (cond, trs) in enumerate(cond_trs):\n",
+    "    betas_averaged[i,:] = np.mean(betas[trs,:], axis=0)\n",
+    "    \n",
+    "pickle.dump(betas_averaged, open(f'betas_averaged_subject_{sub_no}.pkl', 'wb'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Saving the Beta Values\n",
+    "\n",
+    "We saved all results from fitting the GLMSingle object before, but after averaging across stimulus presentations for the `typed` data, it might be a good idea to save a separate copy for easy access as well, as this is what will go directly into the ML pipeline later."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Quality Check "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'wantlibrary': 0, 'wantglmdenoise': 0, 'wantfracridge': 0, 'wantmemoryoutputs': [1, 1, 0, 0], 'wantfileoutputs': [1, 1, 0, 0], 'numforhrf': 50, 'hrfthresh': 0.5, 'hrffitmask': 1, 'R2thresh': 0, 'hrfmodel': 'optimise', 'n_jobs': 1, 'n_pcs': 10, 'n_boots': 100, 'extra_regressors': False, 'chunklen': 50000, 'wanthdf5': 0, 'wantparametric': 0, 'wantpercentbold': 1, 'wantlss': 0, 'brainthresh': [99.0, 0.1], 'brainR2': [], 'brainexclude': False, 'pcR2cutoff': [], 'pcR2cutoffmask': 1, 'pcstop': 1.05, 'fracs': array([1.  , 0.95, 0.9 , 0.85, 0.8 , 0.75, 0.7 , 0.65, 0.6 , 0.55, 0.5 ,\n",
+      "       0.45, 0.4 , 0.35, 0.3 , 0.25, 0.2 , 0.15, 0.1 , 0.05]), 'wantautoscale': 1, 'seed': 1732619319.067295, 'suppressoutput': 0, 'lambda': 0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# for comparison purposes we are going to run a standard GLM\n",
+    "# without HRF fitting, GLMdenoise, or ridge regression regularization. we\n",
+    "# will compute the split-half reliability at each voxel using this baseline\n",
+    "# GLM, and then assess whether reliability improves using the output betas\n",
+    "# from GLMsingle. \n",
+    "\n",
+    "import os \n",
+    "\n",
+    "# output directory for baseline GLM\n",
+    "outputdir_baseline = os.path.join('.','GLMbaseline')\n",
+    "\n",
+    "# we will run this baseline GLM by changing the default settings in GLMsingle \n",
+    "# contained within the \"opt\" structure.\n",
+    "opt = dict() \n",
+    "\n",
+    "# turn off optimizations \n",
+    "opt['wantlibrary'] = 0 # switch off HRF fitting\n",
+    "opt['wantglmdenoise'] = 0 # switch off GLMdenoise\n",
+    "opt['wantfracridge'] = 0 # switch off ridge regression\n",
+    "\n",
+    "\n",
+    "# for the purpose of this example we will keep the relevant outputs in memory\n",
+    "# and also save them to the disk...\n",
+    "# the first two indices are the ON-OFF GLM and the baseline single-trial GLM. \n",
+    "# no need to save the third (+ GLMdenoise) and fourth (+ fracridge) outputs\n",
+    "# since they will not even be computed\n",
+    "opt['wantmemoryoutputs'] = [1,1,0,0] \n",
+    "opt['wantfileoutputs'] = [1,1,0,0]\n",
+    "\n",
+    "# running python GLMsingle involves creating a GLM_single object\n",
+    "# and then running the procedure using the .fit() routine\n",
+    "glmbaseline_obj = GLM_single(opt)\n",
+    "\n",
+    "# visualize the hyperparameters, including the modified baseline opts\n",
+    "print(glmbaseline_obj.params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 177,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loading existing GLMsingle outputs from directory\n"
+     ]
+    }
+   ],
+   "source": [
+    "# if these outputs don't already exist, we will perform the call to\n",
+    "# GLMsingle; otherwise, we will just load from disk.\n",
+    "\n",
+    "outputdir_baseline = './baselineGLM'\n",
+    "if not os.path.exists(outputdir_baseline):\n",
+    "    \n",
+    "    print(f'running GLMsingle...')\n",
+    "\n",
+    "    # run GLMsingle, fitting the baseline GLM\n",
+    "    results_assumehrf = glmbaseline_obj.fit(\n",
+    "        design_list2,\n",
+    "        data_list2,\n",
+    "       stimdur,\n",
+    "       tr,\n",
+    "       outputdir=outputdir_baseline)\n",
+    "    \n",
+    "else:\n",
+    "    \n",
+    "    print(f'loading existing GLMsingle outputs from directory')\n",
+    "    \n",
+    "    results_assumehrf = dict()\n",
+    "    results_assumehrf['typea'] = np.load(os.path.join(outputdir_baseline,'TYPEA_ONOFF.npy'),allow_pickle=True).item()\n",
+    "    results_assumehrf['typeb'] = np.load(os.path.join(outputdir_baseline,'TYPEB_FITHRF.npy'),allow_pickle=True).item()\n",
+    "    \n",
+    "    # note that even though we are loading TYPEB_FITHRF betas, HRF fitting\n",
+    "    # has been turned off and this struct field will thus contain the\n",
+    "    # outputs of a GLM fit using the canonical HRF."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create dictionary containing the GLM betas from the four different models we will compare.\n",
+    "# note that the \"assume hrf\" betas come from the \"typeb\" field of our baseline GLM\n",
+    "# (with HRF fitting turned off), and that the \"fit hrf\" betas also come from \n",
+    "# the \"typeb\" field of the GLM that ran with all default GLMsingle routines\n",
+    "# enabled\n",
+    "\n",
+    "models = dict()\n",
+    "models['assumehrf'] = results_assumehrf['typeb']['betasmd']\n",
+    "models['fithrf'] = results_glmsingle['typeb']['betasmd']\n",
+    "models['fithrf_glmdenoise'] = results_glmsingle['typec']['betasmd']\n",
+    "models['fithrf_glmdenoise_rr'] = results_glmsingle['typed']['betasmd']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "computing reliability for beta version: assumehrf\n",
+      "(163842, 1, 1, 75)\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "index 233 is out of bounds for axis 1 with size 75",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[179], line 16\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;28mprint\u001b[39m(models[modelnames[m]]\u001b[38;5;241m.\u001b[39mshape)\n\u001b[1;32m     15\u001b[0m tmp \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39msqueeze(models[modelnames[m]])\n\u001b[0;32m---> 16\u001b[0m betas \u001b[38;5;241m=\u001b[39m \u001b[43mtmp\u001b[49m\u001b[43m[\u001b[49m\u001b[43m:\u001b[49m\u001b[43m,\u001b[49m\u001b[43mrepTRs\u001b[49m\u001b[43m]\u001b[49m \u001b[38;5;66;03m# automatically reshapes to (X x Y x Z x 2 x nConditions)\u001b[39;00m\n\u001b[1;32m     17\u001b[0m x,y,z \u001b[38;5;241m=\u001b[39m betas\u001b[38;5;241m.\u001b[39mshape[:\u001b[38;5;241m3\u001b[39m] \n\u001b[1;32m     19\u001b[0m rels \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mfull((x,y,z),np\u001b[38;5;241m.\u001b[39mnan)\n",
+      "\u001b[0;31mIndexError\u001b[0m: index 233 is out of bounds for axis 1 with size 75"
+     ]
+    }
+   ],
+   "source": [
+    "# finally, let's compute split-half reliability. we are going to loop\n",
+    "# through our 4 models and calculate split-half reliability for each of them\n",
+    "\n",
+    "vox_reliabilities = [] # output variable for reliability values\n",
+    "\n",
+    "modelnames = list(models.keys())\n",
+    "\n",
+    "# for each beta version...\n",
+    "for m in range(len(modelnames)):\n",
+    "    \n",
+    "    print(f'computing reliability for beta version: {modelnames[m]}')\n",
+    "    \n",
+    "    # get the repeated-condition GLM betas using our repindices variable\n",
+    "    print(models[modelnames[m]].shape)\n",
+    "    tmp = np.squeeze(models[modelnames[m]])\n",
+    "    betas = tmp[:,repTRs] # automatically reshapes to (X x Y x Z x 2 x nConditions)\n",
+    "    x,y,z = betas.shape[:3] \n",
+    "    \n",
+    "    rels = np.full((x,y,z),np.nan)\n",
+    "    \n",
+    "    # loop through voxels in the 3D volume...\n",
+    "    for xx in range(x):\n",
+    "        for yy in range(y):\n",
+    "            for zz in range(z):\n",
+    "                \n",
+    "                # reliability at a given voxel is pearson correlation between response profiles from first and \n",
+    "                # second image presentations (dim = 136 conditions)\n",
+    "                rels[xx,yy,zz] = np.corrcoef(betas[xx,yy,zz,0],\n",
+    "                                             betas[xx,yy,zz,1])[1,0]\n",
+    "          \n",
+    "    vox_reliabilities.append(rels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## New way to implement\n",
+    "\n",
+    "* Shuffle the conditions so repetitions are out\n",
+    "* Then this should interfere with the ability to get good reps\n",
+    "* Then do the typed for shuffled and unshuffled \n",
+    "* Then take the subtraction of the R^2 and plot the gain on the hemispheres."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'wantlibrary': 1, 'wantglmdenoise': 1, 'wantfracridge': 1, 'wantfileoutputs': [1, 1, 1, 1], 'wantmemoryoutputs': [1, 1, 1, 1], 'numforhrf': 50, 'hrfthresh': 0.5, 'hrffitmask': 1, 'R2thresh': 0, 'hrfmodel': 'optimise', 'n_jobs': 1, 'n_pcs': 10, 'n_boots': 100, 'extra_regressors': False, 'chunklen': 50000, 'wanthdf5': 0, 'wantparametric': 0, 'wantpercentbold': 1, 'wantlss': 0, 'brainthresh': [99.0, 0.1], 'brainR2': [], 'brainexclude': False, 'pcR2cutoff': [], 'pcR2cutoffmask': 1, 'pcstop': 1.05, 'fracs': array([1.  , 0.95, 0.9 , 0.85, 0.8 , 0.75, 0.7 , 0.65, 0.6 , 0.55, 0.5 ,\n",
+      "       0.45, 0.4 , 0.35, 0.3 , 0.25, 0.2 , 0.15, 0.1 , 0.05]), 'wantautoscale': 1, 'seed': 1732619319.067295, 'suppressoutput': 0, 'lambda': 0}\n",
+      "*** DIAGNOSTICS ***:\n",
+      "There are 12 runs.\n",
+      "The number of conditions in this experiment is 300.\n",
+      "The stimulus duration corresponding to each trial is 2.00 seconds.\n",
+      "The TR (time between successive data points) is 1.97 seconds.\n",
+      "The number of trials in each run is: [38, 37, 38, 37, 38, 37, 38, 37, 38, 37, 38, 37].\n",
+      "The number of trials for each condition is: [np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(3), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0)].\n",
+      "For each condition, the number of runs in which it appears: [np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(2), np.int64(1), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(2), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(1), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(1), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(1), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(2), np.int64(1), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(1), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(2), np.int64(1), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(1), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(1), np.int64(1), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(1), np.int64(2), np.int64(2), np.int64(2), np.int64(1), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(2), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0)].\n",
+      "For each run, how much ending buffer do we have in seconds? [np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76)].\n",
+      "*** Saving design-related results to ./output/DESIGNINFO.npy. ***\n",
+      "*** FITTING DIAGNOSTIC RUN-WISE FIR MODEL ***\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alxmrphi/miniforge3/envs/glmsingle_demo/lib/python3.10/site-packages/glmsingle/glmsingle.py:659: UserWarning: Warning: You have specified trial onsets that occur less than 8 seconds from the end of at least one of the runs. This may cause estimation problems! As a solution, consider simply omitting specification of these ending trials from the original design matrix.\n",
+      "  warnings.warn(msg)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*** Saving FIR results to ./output/RUNWISEFIR.npy. ***\n",
+      "\n",
+      "*** FITTING TYPE-A MODEL (ONOFF) ***\n",
+      "\n",
+      "fitting model...\n",
+      "done.\n",
+      "\n",
+      "preparing output...\n",
+      "done.\n",
+      "\n",
+      "computing model fits...\n",
+      "done.\n",
+      "\n",
+      "computing R^2...\n",
+      "done.\n",
+      "\n",
+      "computing SNR...\n",
+      "done.\n",
+      "\n",
+      "\n",
+      "*** Saving results to ./output/TYPEA_ONOFF.npy. ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alxmrphi/miniforge3/envs/glmsingle_demo/lib/python3.10/site-packages/sklearn/mixture/_base.py:270: ConvergenceWarning: Best performing initialization did not converge. Try different init parameters, or increase max_iter, tol, or check for degenerate data.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*** Setting brain R2 threshold to 0.11392115427327491 ***\n",
+      "\n",
+      "*** FITTING TYPE-B MODEL (FITHRF) ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:   0%|          | 0/4 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  25%|██▌       | 1/4 [00:29<01:28, 29.40s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  50%|█████     | 2/4 [00:58<00:57, 28.96s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  75%|███████▌  | 3/4 [01:26<00:28, 28.52s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [01:56<00:00, 29.03s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** Saving results to ./output/TYPEB_FITHRF.npy. ***\n",
+      "\n",
+      "*** DETERMINING GLMDENOISE REGRESSORS ***\n",
+      "\n",
+      "*** CROSS-VALIDATING DIFFERENT NUMBERS OF REGRESSORS ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:   0%|          | 0/4 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  25%|██▌       | 1/4 [00:29<01:27, 29.05s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  50%|█████     | 2/4 [00:57<00:57, 28.88s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  75%|███████▌  | 3/4 [01:26<00:28, 28.87s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [01:54<00:00, 28.73s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** FITTING TYPE-C MODEL (GLMDENOISE) ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [00:16<00:00,  4.17s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** Saving results to ./output/TYPEC_FITHRF_GLMDENOISE.npy. ***\n",
+      "\n",
+      "*** FITTING TYPE-D MODEL (GLMDENOISE_RR) ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [04:13<00:00, 63.30s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** Saving results to ./output/TYPED_FITHRF_GLMDENOISE_RR.npy. ***\n",
+      "\n",
+      "*** All model types done ***\n",
+      "\n",
+      "*** return model types in results ***\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "opt = dict()\n",
+    "# set important fields for completeness (but these would be enabled by default)\n",
+    "opt['wantlibrary'] = 1\n",
+    "opt['wantglmdenoise'] = 1\n",
+    "opt['wantfracridge'] = 1\n",
+    "\n",
+    "# for the purpose of this example we will keep the relevant outputs in memory\n",
+    "# and also save them to the disk\n",
+    "opt['wantfileoutputs'] = [1,1,1,1]\n",
+    "opt['wantmemoryoutputs'] = [1,1,1,1]\n",
+    "\n",
+    "# running python GLMsingle involves creating a GLM_single object\n",
+    "# and then running the procedure using the .fit() routine\n",
+    "glmsingle_obj = GLM_single(opt)\n",
+    "\n",
+    "# visualize all the hyperparameters\n",
+    "print(glmsingle_obj.params)\n",
+    "\n",
+    "tr = 1.97\n",
+    "stimdur = 2.0\n",
+    "\n",
+    "np.random.shuffle(data_list2)\n",
+    "\n",
+    "results_glmshuffle = glmsingle_obj.fit(\n",
+    "    design_list2,\n",
+    "    data_list2,\n",
+    "    stimdur,\n",
+    "    tr,\n",
+    "    outputdir='./output')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 191,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r2_real = results_glmsingle['typed']['R2']\n",
+    "r2_shuffle = results_glmshuffle['typed']['R2']\n",
+    "\n",
+    "gain = r2_real - r2_shuffle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 192,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(163842, 1, 1)"
+      ]
+     },
+     "execution_count": 192,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gain.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot the difference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 195,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#view = plotting.view_surf(fsaverage.infl_left, gain, symmetric_cmap=True)\n",
+    "#view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that when we shuffled `data_list2` such that the condition and temporal order was not in the correct order, there is a drop in the `R2` value, particularly in visual cortex in the occipital lobe. This tells us that when we used the original ordering, there is a gain in `R2`. This result confirms that the signal is likely correct in the setup derived to get these beta values in our experimental setup. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "glmsingle_demo",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/glmsingle_qc.ipynb
+++ b/glmsingle_qc.ipynb
@@ -1,0 +1,885 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# GLMSingle Quality Check\n",
+    "\n",
+    "The purpose of this notebook is to contrast a standard GLM set of responses over a dataset with the GLMSingle-optimised ones. The example given in the GLMSingle Python demonstration is primarily organised around fitting voxel data, while in this project we are primarily using vertex data. This doesn't mean that there is much of a difference, beyond using the GiFTI files that are split per-hemisphere, but for quick verification / quality checking of the preprocessing steps, it's worth a separate notebook to explain the process. \n",
+    "\n",
+    "The steps involved in this notebook are: \n",
+    "* Pick a single subject's data\n",
+    "* Apply GLMSingle to it\n",
+    "* Extract the $R{^2}$ value averaged across repetitions \n",
+    "* Apply standard GLM to the same data\n",
+    "* Also extract the $R{^2}$ value for that model\n",
+    "* Calculate $R{^2}$ gain by subtracting canonical GLM betas from the GLMSingle ones\n",
+    "* Any positive gain shows increased sensitivity to the GLMSingle process\n",
+    "* Positive gain indicates the GLMSingle betas are better fit, which is what we expect"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np \n",
+    "\n",
+    "from glmsingle.glmsingle import GLM_single\n",
+    "from glmsingle_utils import get_data_and_design_matrices\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sub_no = 35\n",
+    "n_timepoints = 236\n",
+    "hemi = 'lh'\n",
+    "func_folder = Path('/Users/alxmrphi/Documents/Data/Bird/jamestest/TC2See_35/study/sub-35/sub-35/func')\n",
+    "events_folder = Path('/Users/alxmrphi/Documents/Data/Bird/jamestest/Tc2See_35/study/csv_files')\n",
+    "\n",
+    "design1, data1 = get_data_and_design_matrices(sub_no, func_folder, events_folder, hemi, 1, n_timepoints)\n",
+    "design2, data2 = get_data_and_design_matrices(sub_no, func_folder, events_folder, hemi, 1, n_timepoints)\n",
+    "design3, data3 = get_data_and_design_matrices(sub_no, func_folder, events_folder, hemi, 1, n_timepoints)\n",
+    "design4, data4 = get_data_and_design_matrices(sub_no, func_folder, events_folder, hemi, 1, n_timepoints)\n",
+    "design5, data5 = get_data_and_design_matrices(sub_no, func_folder, events_folder, hemi, 1, n_timepoints)\n",
+    "design6, data6 = get_data_and_design_matrices(sub_no, func_folder, events_folder, hemi, 1, n_timepoints)\n",
+    "\n",
+    "data1_ = StandardScaler().fit_transform(data1)\n",
+    "data2_ = StandardScaler().fit_transform(data2)\n",
+    "data3_ = StandardScaler().fit_transform(data3)\n",
+    "data4_ = StandardScaler().fit_transform(data4)\n",
+    "data5_ = StandardScaler().fit_transform(data5)\n",
+    "data6_ = StandardScaler().fit_transform(data6)\n",
+    "\n",
+    "data_list = [data1_, data2_, data3_, data4_, data5_, data6_]\n",
+    "design_list = [design1, design2, design3, design4, design5, design6]\n",
+    "\n",
+    "split_val = 118\n",
+    "\n",
+    "design_list2 = [design_list[0][:split_val,:], design_list[0][split_val:,:], design_list[1][:split_val,:],\n",
+    "                design_list[1][split_val:,:], design_list[2][:split_val,:], design_list[2][split_val:,:],\n",
+    "                design_list[3][:split_val,:], design_list[3][split_val:,:], design_list[4][:split_val,:],\n",
+    "                design_list[4][split_val:,:], design_list[5][:split_val,:], design_list[5][split_val:,:]]\n",
+    "\n",
+    "data_list2 = [data_list[0][:,:split_val], data_list[0][:,split_val:], data_list[1][:,:split_val],\n",
+    "                data_list[1][:,split_val:], data_list[2][:,:split_val], data_list[2][:,split_val:],\n",
+    "                data_list[3][:,:split_val], data_list[3][:,split_val:], data_list[4][:,:split_val],\n",
+    "                data_list[4][:,split_val:], data_list[5][:,:split_val], data_list[5][:,split_val:]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*** DIAGNOSTICS ***:\n",
+      "There are 12 runs.\n",
+      "The number of conditions in this experiment is 300.\n",
+      "The stimulus duration corresponding to each trial is 2.00 seconds.\n",
+      "The TR (time between successive data points) is 1.97 seconds.\n",
+      "The number of trials in each run is: [38, 37, 38, 37, 38, 37, 38, 37, 38, 37, 38, 37].\n",
+      "The number of trials for each condition is: [np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0)].\n",
+      "For each condition, the number of runs in which it appears: [np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(12), np.int64(12), np.int64(12), np.int64(12), np.int64(6), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(6), np.int64(12), np.int64(6), np.int64(6), np.int64(12), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(6), np.int64(6), np.int64(12), np.int64(12), np.int64(12), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(6), np.int64(12), np.int64(6), np.int64(6), np.int64(12), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(12), np.int64(12), np.int64(12), np.int64(12), np.int64(12), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0)].\n",
+      "For each run, how much ending buffer do we have in seconds? [np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76)].\n",
+      "*** Saving design-related results to ./tmp_output_full/DESIGNINFO.npy. ***\n",
+      "*** FITTING DIAGNOSTIC RUN-WISE FIR MODEL ***\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alxmrphi/miniforge3/envs/glmsingle_demo/lib/python3.10/site-packages/glmsingle/glmsingle.py:659: UserWarning: Warning: You have specified trial onsets that occur less than 8 seconds from the end of at least one of the runs. This may cause estimation problems! As a solution, consider simply omitting specification of these ending trials from the original design matrix.\n",
+      "  warnings.warn(msg)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*** Saving FIR results to ./tmp_output_full/RUNWISEFIR.npy. ***\n",
+      "\n",
+      "*** FITTING TYPE-A MODEL (ONOFF) ***\n",
+      "\n",
+      "fitting model...\n",
+      "done.\n",
+      "\n",
+      "preparing output...\n",
+      "done.\n",
+      "\n",
+      "computing model fits...\n",
+      "done.\n",
+      "\n",
+      "computing R^2...\n",
+      "done.\n",
+      "\n",
+      "computing SNR...\n",
+      "done.\n",
+      "\n",
+      "\n",
+      "*** Saving results to ./tmp_output_full/TYPEA_ONOFF.npy. ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alxmrphi/miniforge3/envs/glmsingle_demo/lib/python3.10/site-packages/sklearn/mixture/_base.py:270: ConvergenceWarning: Best performing initialization did not converge. Try different init parameters, or increase max_iter, tol, or check for degenerate data.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*** Setting brain R2 threshold to 0.5888332659826737 ***\n",
+      "\n",
+      "*** FITTING TYPE-B MODEL (FITHRF) ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:   0%|          | 0/4 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  25%|██▌       | 1/4 [00:29<01:27, 29.20s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  50%|█████     | 2/4 [00:57<00:57, 28.57s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  75%|███████▌  | 3/4 [01:24<00:27, 27.98s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [01:52<00:00, 28.09s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** Saving results to ./tmp_output_full/TYPEB_FITHRF.npy. ***\n",
+      "\n",
+      "*** DETERMINING GLMDENOISE REGRESSORS ***\n",
+      "\n",
+      "*** CROSS-VALIDATING DIFFERENT NUMBERS OF REGRESSORS ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:   0%|          | 0/4 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  25%|██▌       | 1/4 [00:32<01:36, 32.30s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  50%|█████     | 2/4 [01:03<01:03, 31.63s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks:  75%|███████▌  | 3/4 [01:37<00:32, 32.60s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n",
+      "Warning: One or more regressors are all zeros; we will estimate a 0 weight for those regressors.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [02:10<00:00, 32.60s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** FITTING TYPE-C MODEL (GLMDENOISE) ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [00:17<00:00,  4.44s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** Saving results to ./tmp_output_full/TYPEC_FITHRF_GLMDENOISE.npy. ***\n",
+      "\n",
+      "*** FITTING TYPE-D MODEL (GLMDENOISE_RR) ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [04:37<00:00, 69.44s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** Saving results to ./tmp_output_full/TYPED_FITHRF_GLMDENOISE_RR.npy. ***\n",
+      "\n",
+      "*** All model types done ***\n",
+      "\n",
+      "*** return model types in results ***\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "opt = dict()\n",
+    "opt['wantlibrary'] = 1\n",
+    "opt['wantglmdenoise'] = 1\n",
+    "opt['wantfracridge'] = 1\n",
+    "opt['wantfileoutputs'] = [1,1,1,1]\n",
+    "opt['wantmemoryoutputs'] = [1,1,1,1]\n",
+    "\n",
+    "# running python GLMsingle involves creating a GLM_single object\n",
+    "# and then running the procedure using the .fit() routine\n",
+    "glmsingle_obj = GLM_single(opt)\n",
+    "tr = 1.97\n",
+    "stimdur = 2.0\n",
+    "\n",
+    "results_glmsingle = glmsingle_obj.fit(\n",
+    "    design_list2,\n",
+    "    data_list2,\n",
+    "    stimdur,\n",
+    "    tr,\n",
+    "    outputdir=f'./tmp_output_full/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r2_full = np.squeeze(results_glmsingle['typed']['R2'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we run the same data through GLMSingle again but this time only with the canonical HRF to get baseline beta values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*** DIAGNOSTICS ***:\n",
+      "There are 12 runs.\n",
+      "The number of conditions in this experiment is 300.\n",
+      "The stimulus duration corresponding to each trial is 2.00 seconds.\n",
+      "The TR (time between successive data points) is 1.97 seconds.\n",
+      "The number of trials in each run is: [38, 37, 38, 37, 38, 37, 38, 37, 38, 37, 38, 37].\n",
+      "The number of trials for each condition is: [np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(18), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0)].\n",
+      "For each condition, the number of runs in which it appears: [np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(12), np.int64(12), np.int64(12), np.int64(12), np.int64(6), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(6), np.int64(12), np.int64(6), np.int64(6), np.int64(12), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(6), np.int64(6), np.int64(12), np.int64(12), np.int64(12), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(6), np.int64(12), np.int64(6), np.int64(6), np.int64(12), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(12), np.int64(12), np.int64(12), np.int64(12), np.int64(12), np.int64(0), np.int64(0), np.int64(0), np.int64(0), np.int64(0)].\n",
+      "For each run, how much ending buffer do we have in seconds? [np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76), np.float64(1.97), np.float64(15.76)].\n",
+      "*** Saving design-related results to ./tmp_output_baseline/DESIGNINFO.npy. ***\n",
+      "*** FITTING DIAGNOSTIC RUN-WISE FIR MODEL ***\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alxmrphi/miniforge3/envs/glmsingle_demo/lib/python3.10/site-packages/glmsingle/glmsingle.py:659: UserWarning: Warning: You have specified trial onsets that occur less than 8 seconds from the end of at least one of the runs. This may cause estimation problems! As a solution, consider simply omitting specification of these ending trials from the original design matrix.\n",
+      "  warnings.warn(msg)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*** Saving FIR results to ./tmp_output_baseline/RUNWISEFIR.npy. ***\n",
+      "\n",
+      "*** FITTING TYPE-A MODEL (ONOFF) ***\n",
+      "\n",
+      "fitting model...\n",
+      "done.\n",
+      "\n",
+      "preparing output...\n",
+      "done.\n",
+      "\n",
+      "computing model fits...\n",
+      "done.\n",
+      "\n",
+      "computing R^2...\n",
+      "done.\n",
+      "\n",
+      "computing SNR...\n",
+      "done.\n",
+      "\n",
+      "\n",
+      "*** Saving results to ./tmp_output_baseline/TYPEA_ONOFF.npy. ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alxmrphi/miniforge3/envs/glmsingle_demo/lib/python3.10/site-packages/sklearn/mixture/_base.py:270: ConvergenceWarning: Best performing initialization did not converge. Try different init parameters, or increase max_iter, tol, or check for degenerate data.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "*** Setting brain R2 threshold to 0.5888332659826737 ***\n",
+      "\n",
+      "*** FITTING TYPE-B MODEL (FITHRF) ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "chunks: 100%|██████████| 4/4 [00:07<00:00,  1.86s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "*** Saving results to ./tmp_output_baseline/TYPEB_FITHRF.npy. ***\n",
+      "\n",
+      "*** All model types done ***\n",
+      "\n",
+      "*** return model types in results ***\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "opt = dict() \n",
+    "opt['wantlibrary'] = 0 # switch off HRF fitting\n",
+    "opt['wantglmdenoise'] = 0 # switch off GLMdenoise\n",
+    "opt['wantfracridge'] = 0 # switch off ridge regression\n",
+    "# for the purpose of this example we will keep the relevant outputs in memory\n",
+    "# and also save them to the disk...\n",
+    "# the first two indices are the ON-OFF GLM and the baseline single-trial GLM. \n",
+    "# no need to save the third (+ GLMdenoise) and fourth (+ fracridge) outputs\n",
+    "# since they will not even be computed\n",
+    "opt['wantmemoryoutputs'] = [1,1,0,0] \n",
+    "opt['wantfileoutputs'] = [1,1,0,0]\n",
+    "\n",
+    "glmbaseline_obj = GLM_single(opt)\n",
+    "tr = 1.97\n",
+    "stimdur = 2.0\n",
+    "\n",
+    "results_glmbaseline = glmbaseline_obj.fit(\n",
+    "    design_list2,\n",
+    "    data_list2,\n",
+    "    stimdur,\n",
+    "    tr,\n",
+    "    outputdir=f'./tmp_output_baseline/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# typeb is where you would usually extract the fitted HRFs but because it was switched off (`opt['wantlibrary'] = 0`)\n",
+    "# in our case, this means it's just the canonical HRF that is applied and so this is the correct R2 to use.\n",
+    "r2_baseline = np.squeeze(results_glmbaseline['typeb']['R2'])\n",
+    "\n",
+    "r2_full = np.squeeze(results_glmsingle['typed']['R2'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gain = r2_full - r2_baseline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Visualisation\n",
+    "\n",
+    "Now we can visualise the $R{^2}$ gain in using GLMSingle over the canonical GLM and plot on the inflated LH surface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nilearn\n",
+    "import nilearn.datasets as datasets\n",
+    "from nilearn import datasets\n",
+    "from nilearn import plotting\n",
+    "\n",
+    "fsaverage = datasets.fetch_surf_fsaverage(mesh='fsaverage')\n",
+    "r2_full = np.clip(r2_full, a_min=0, a_max=85)\n",
+    "\n",
+    "infl = fsaverage.infl_left if hemi == 'lh' else fsaverage.infl_right\n",
+    "view = plotting.view_surf(infl, r2_full, symmetric_cmap=False)\n",
+    "# view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot the Gain\n",
+    "\n",
+    "The gain value is of a much smaller magnitude between both conditions so it makes sense to clip the maximum value to be 10-15 (I choose 15 here). This then reveals patches in the visual cortex, in the medial lobe and along the ventral visual pathway that have increases in R^2 gain of about 10-20%, which represents increase in signal quality over and above the canonical GLM beta weights. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gain_clipped = np.clip(gain, a_min=0, a_max=15)\n",
+    "view = plotting.view_surf(infl, gain_clipped, symmetric_cmap=True)\n",
+    "# view"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "glmsingle_demo",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/glmsingle_utils.py
+++ b/glmsingle_utils.py
@@ -1,0 +1,75 @@
+import os
+import pickle 
+import pandas as pd
+import numpy as np
+
+from pathlib import Path
+from nilearn import surface as surf
+
+# Suppress warnings
+pd.options.mode.chained_assignment = None
+
+
+idx_to_fname = pickle.load(open('idx_to_fname.pkl', 'rb'))
+fname_to_idx = pickle.load(open('fname_to_idx.pkl', 'rb'))
+
+# Helpers to add columns to the events dataframe
+def process_stim_column(stimulus):
+    assert type(stimulus) == str
+    return stimulus.split('.')[1:-1][0]
+    
+def stimulus_to_class(stimulus):
+    return fname_to_idx[stimulus]
+
+
+def get_data_and_design_matrices(sub_no: int,
+                                 func_folder: os.PathLike,
+                                 events_folder: os.PathLike,
+                                 hemi: str,
+                                 run_no: int,
+                                 n_timepoints: int) -> tuple:
+    
+    """ This helper function specifies a subject, a run, a hemisphere and returns
+    the design matrix and functional data for that subject, run and hemisphere.
+    
+    Args:
+        sub_no (int): The subject number
+        func_folder (os.Pathlike): The path to the folder containing the functional data
+        events_folder (os.Pathlike): The path to the folder containing the events data
+        hemi (str): The hemisphere of the brain. Must be in {lh, rh}
+        run_no (int): The run number
+        n_timepoints (int): The number of timepoints in the functional data
+    
+    """
+
+    assert hemi in ['lh', 'rh'], "Argument 'hemi' must be either 'lh' or 'rh'"
+    hemi = 'L' if hemi == 'lh' else 'R'
+
+    # Load functional data
+    func_file = Path(f'sub-{sub_no}_task-bird_run-{run_no}_hemi-{hemi}_space-fsaverage_bold.func.gii')
+    data = surf.load_surf_data(func_folder / func_file)
+
+    # Load events data and process it
+    file = Path(f'TC2See_{sub_no}_{run_no}_result_store.csv')
+    path = events_folder / file
+    df = pd.read_csv(path, sep='\t')
+    events_df = df[df['stimulus'].str.endswith('png')] 
+    events_df['filename'] = events_df['stimulus'].apply(process_stim_column)
+    events_df['file_id'] = events_df['filename'].apply(stimulus_to_class)
+
+    # Create design matrix
+    n_conds = len(idx_to_fname.keys())
+    assert n_conds == 300, "Number of conditions must be 300"
+    design = np.zeros((n_timepoints, n_conds))
+
+    # Each row in the events dataframe details presentation of a bird image.
+    # For each row, we want to extract which TR this occurred at and a file ID.
+    # The file ID is the mapping of the stimulus filename to the global stimulus class ID
+    # found in `idx_to_fname.pkl` and `fname_to_idx.pkl`.
+    # We then set the corresponding entry in the design matrix to 1.
+    for t in range(len(events_df)):
+        tr, idx = events_df.iloc[t][['tr', 'file_id']]
+        tr = int(tr)
+        design[tr, idx] = 1
+
+    return design, data


### PR DESCRIPTION
The file `glmsingle_utils.py` contains basic code to extract GLMSingle information when doing preprocessing of the GLMSingle beta weights. The file `glmsingle_qc.ipynb` is a demonstration on subject 35, left hemisphere, that there is a gain of around 15-20% in R^2 when using GLMSingle over and above beta weights derived from using a standard GLM with canonical HRF function. This notebook shows code for how to calculate this and visualise this on an `fsaverage` inflated surface. 